### PR TITLE
Add PHP 7.4 targets to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,12 @@ matrix:
     - php: 7.3
       env:
         - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi


### PR DESCRIPTION
https://github.com/laminas/laminas-ldap/pull/7#discussion_r392106559

May as well have 7.4 tests run but also, we can hopefully then see the difference in the referenced pull request.