### PR TITLE
Support PHP 7.3 7.4 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.result.cache
 /clover.xml
 /composer.lock
 /coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,9 @@ matrix:
     - php: 8.0
       env:
         - DEPS=lowest
-        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - php: 8.0
       env:
         - DEPS=latest
-        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: focal
 
 language: php
 
@@ -22,44 +22,30 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.3
+      dist: bionic
       env:
         - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
+      dist: bionic
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
-        - DEPS=latest
     - php: 7.4
       env:
         - DEPS=lowest
     - php: 7.4
       env:
         - DEPS=latest
+    - php: 8.0
+      env:
+        - DEPS=lowest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - php: 8.0
+      env:
+        - DEPS=latest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "extra": {
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ~8.0.0",
         "ext-ldap": "*",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
@@ -31,7 +31,7 @@
         "laminas/laminas-eventmanager": "^2.6.3 || ^3.0.1",
         "laminas/laminas-stdlib": "^2.7 || ^3.0",
         "php-mock/php-mock-phpunit": "^1.1.2 || ^2.1.1",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20"
+        "phpunit/phpunit": "^9.5.0"
     },
     "suggest": {
         "laminas/laminas-eventmanager": "Laminas\\EventManager component"

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
     "require": {
         "php": "^7.3 || ~8.0.0",
         "ext-ldap": "*",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-zendframework-bridge": "^1.1"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "laminas/laminas-config": "^2.5",
-        "laminas/laminas-eventmanager": "^2.6.3 || ^3.0.1",
-        "laminas/laminas-stdlib": "^2.7 || ^3.0",
-        "php-mock/php-mock-phpunit": "^1.1.2 || ^2.1.1",
+        "laminas/laminas-config": "^3.4",
+        "laminas/laminas-eventmanager": "^3.3",
+        "laminas/laminas-stdlib": "^3.3",
+        "php-mock/php-mock-phpunit": "^2.6",
         "phpunit/phpunit": "^9.5.0"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="test/bootstrap.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="laminas-ldap Test Suite">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-
-    <php>
-        <!-- Laminas\Ldap online tests
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd" bootstrap="test/bootstrap.php" colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="laminas-ldap Test Suite">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <!-- Laminas\Ldap online tests
 
              These largely map to the options described in the Laminas\Ldap and
              Laminas\Auth\Adapter\Ldap documentation.
@@ -48,27 +43,27 @@
                                 ALT_DN: CN=Alice Baker,OU=Sales,DC=foo,DC=net
                           ALT_PASSWORD: apass
         -->
-        <env name="TESTS_LAMINAS_LDAP_ONLINE_ENABLED" value="false" />
-        <env name="TESTS_LAMINAS_LDAP_HOST" value="localhost" />
-        <env name="TESTS_LAMINAS_LDAP_PORT" value="3890" />
-        <env name="TESTS_LAMINAS_LDAP_SCRIPTS_PORT" value="3891" />
-        <env name="TESTS_LAMINAS_LDAP_USE_START_TLS" value="false" />
-        <env name="TESTS_LAMINAS_LDAP_USE_SSL" value="false" />
-        <env name="TESTS_LAMINAS_LDAP_USERNAME" value="cn=Manager,dc=example,dc=com" />
-        <env name="TESTS_LAMINAS_LDAP_PASSWORD" value="insecure" />
-        <env name="TESTS_LAMINAS_LDAP_BIND_REQUIRES_DN" value="true" />
-        <env name="TESTS_LAMINAS_LDAP_BASE_DN" value="dc=example,dc=com" />
-        <env name="TESTS_LAMINAS_LDAP_ACCOUNT_FILTER_FORMAT" value="(&amp;(objectClass=account)(uid=%s))" />
-        <env name="TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME" value="example.com" />
-        <env name="TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME_SHORT" value="EXAMPLE" />
-        <env name="TESTS_LAMINAS_LDAP_ALT_USERNAME" value="user1" />
-        <env name="TESTS_LAMINAS_LDAP_ALT_PRINCIPAL_NAME" value="user1@example.com" />
-        <env name="TESTS_LAMINAS_LDAP_ALT_DN" value="uid=user1,dc=example,dc=com" />
-        <env name="TESTS_LAMINAS_LDAP_ALT_PASSWORD" value="user1" />
-        <env name="TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE" value="ou=test,dc=example,dc=com" />
-        <env name="TESTS_LAMINAS_LDAP_ANONYMOUS_BIND_ALLOWED" value="true"/>
-        <env name="TESTS_LAMINAS_LDAP_SASL_CERTIFICATE" value="/tmp/client.crt" />
-        <env name="TESTS_LAMINAS_LDAP_SASL_KEY" value="/tmp/client.key" />
-        <env name="TESTS_LAMINAS_LDAP_IDLE_TIMEOUT" value="4" />
-    </php>
+    <env name="TESTS_LAMINAS_LDAP_ONLINE_ENABLED" value="false"/>
+    <env name="TESTS_LAMINAS_LDAP_HOST" value="localhost"/>
+    <env name="TESTS_LAMINAS_LDAP_PORT" value="3890"/>
+    <env name="TESTS_LAMINAS_LDAP_SCRIPTS_PORT" value="3891"/>
+    <env name="TESTS_LAMINAS_LDAP_USE_START_TLS" value="false"/>
+    <env name="TESTS_LAMINAS_LDAP_USE_SSL" value="false"/>
+    <env name="TESTS_LAMINAS_LDAP_USERNAME" value="cn=Manager,dc=example,dc=com"/>
+    <env name="TESTS_LAMINAS_LDAP_PASSWORD" value="insecure"/>
+    <env name="TESTS_LAMINAS_LDAP_BIND_REQUIRES_DN" value="true"/>
+    <env name="TESTS_LAMINAS_LDAP_BASE_DN" value="dc=example,dc=com"/>
+    <env name="TESTS_LAMINAS_LDAP_ACCOUNT_FILTER_FORMAT" value="(&amp;(objectClass=account)(uid=%s))"/>
+    <env name="TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME" value="example.com"/>
+    <env name="TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME_SHORT" value="EXAMPLE"/>
+    <env name="TESTS_LAMINAS_LDAP_ALT_USERNAME" value="user1"/>
+    <env name="TESTS_LAMINAS_LDAP_ALT_PRINCIPAL_NAME" value="user1@example.com"/>
+    <env name="TESTS_LAMINAS_LDAP_ALT_DN" value="uid=user1,dc=example,dc=com"/>
+    <env name="TESTS_LAMINAS_LDAP_ALT_PASSWORD" value="user1"/>
+    <env name="TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE" value="ou=test,dc=example,dc=com"/>
+    <env name="TESTS_LAMINAS_LDAP_ANONYMOUS_BIND_ALLOWED" value="true"/>
+    <env name="TESTS_LAMINAS_LDAP_SASL_CERTIFICATE" value="/tmp/client.crt"/>
+    <env name="TESTS_LAMINAS_LDAP_SASL_KEY" value="/tmp/client.key"/>
+    <env name="TESTS_LAMINAS_LDAP_IDLE_TIMEOUT" value="4"/>
+  </php>
 </phpunit>

--- a/src/Collection/DefaultIterator.php
+++ b/src/Collection/DefaultIterator.php
@@ -350,7 +350,7 @@ class DefaultIterator implements Iterator, Countable
      *
      * The callable has to accept two parameters that will be compared.
      *
-     * @param callable $sortingAlgorithm The algorithm to be used for sorting
+     * @param callable $sortFunction The algorithm to be used for sorting
      *
      * @return DefaultIterator Provides a fluent interface
      */

--- a/src/Ldap.php
+++ b/src/Ldap.php
@@ -133,7 +133,10 @@ class Ldap
     public function getLastErrorCode()
     {
         ErrorHandler::start(E_WARNING);
-        $ret = ldap_get_option($this->resource, LDAP_OPT_ERROR_NUMBER, $err);
+        $ret = false;
+        if (is_resource($this->resource)) {
+            $ret = ldap_get_option($this->resource, LDAP_OPT_ERROR_NUMBER, $err);
+        }
         ErrorHandler::stop();
         if ($ret === true) {
             if ($err <= -1 && $err >= -17) {
@@ -165,7 +168,10 @@ class Ldap
          * can and eliminate dupes.
          */
         ErrorHandler::start(E_WARNING);
-        $estr1 = ldap_error($this->resource);
+        $estr1 = "getLastError: could not call ldap_error because LDAP resource was not of type resource";
+        if (is_resource($this->resource)) {
+            $estr1 = ldap_error($this->resource);
+        }
         ErrorHandler::stop();
         if ($errorCode !== 0 && $estr1 === 'Success') {
             ErrorHandler::start(E_WARNING);
@@ -177,7 +183,10 @@ class Ldap
         }
 
         ErrorHandler::start(E_WARNING);
-        ldap_get_option($this->resource, LDAP_OPT_ERROR_STRING, $estr2);
+        $estr2 = "getLastError: could not call ldap_get_option because LDAP resource was not of type resource";
+        if (is_resource($this->resource)) {
+            ldap_get_option($this->resource, LDAP_OPT_ERROR_STRING, $estr2);
+        }
         ErrorHandler::stop();
         if (! empty($estr2) && ! in_array($estr2, $errorMessages)) {
             $errorMessages[] = $estr2;
@@ -733,7 +742,7 @@ class Ldap
 
     protected function unbind()
     {
-        if (is_resource($this->resource)) {
+        if (is_resource($this->resource) && is_string($this->boundUser)) {
             ErrorHandler::start(E_WARNING);
             ldap_unbind($this->resource);
             ErrorHandler::stop();
@@ -973,6 +982,8 @@ class Ldap
                 $this->boundUser = $username;
                 return $this;
             }
+
+            $this->boundUser = false;
 
             if ($this->shouldReconnect($this->resource)) {
                 return $this;

--- a/test/AbstractOnlineTestCase.php
+++ b/test/AbstractOnlineTestCase.php
@@ -20,7 +20,7 @@ abstract class AbstractOnlineTestCase extends AbstractTestCase
      */
     private static $ldap;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $options = [
             'host'     => getenv('TESTS_LAMINAS_LDAP_HOST'),
@@ -53,7 +53,7 @@ abstract class AbstractOnlineTestCase extends AbstractTestCase
         self::$ldap = new Ldap\Ldap($options);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         if (self::$ldap !== null) {
             self::$ldap->disconnect();
@@ -74,7 +74,7 @@ abstract class AbstractOnlineTestCase extends AbstractTestCase
         return self::$ldap;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! getenv('TESTS_LAMINAS_LDAP_ONLINE_ENABLED')) {
             $this->markTestSkipped("Laminas_Ldap online tests are not enabled");

--- a/test/AttributeTest.php
+++ b/test/AttributeTest.php
@@ -65,7 +65,7 @@ class AttributeTest extends TestCase
         $value = Attribute::getAttribute($data, 'uid2', 0);
         $this->assertNull($value);
         $array = Attribute::getAttribute($data, 'uid2');
-        $this->assertInternalType('array', $array);
+        $this->assertIsArray($array);
         $this->assertCount(0, $array);
     }
 
@@ -82,7 +82,7 @@ class AttributeTest extends TestCase
     {
         $data  = ['uid' => ['value']];
         $value = Attribute::getAttribute($data, 'uid');
-        $this->assertInternalType('array', $value);
+        $this->assertIsArray($value);
         $this->assertCount(1, $value);
         $this->assertContains('value', $value);
     }
@@ -92,7 +92,7 @@ class AttributeTest extends TestCase
         $data = [];
         Attribute::setAttribute($data, 'uid', 'new', false);
         $this->assertArrayHasKey('uid', $data);
-        $this->assertInternalType('array', $data['uid']);
+        $this->assertIsArray($data['uid']);
         $this->assertCount(1, $data['uid']);
         $this->assertContains('new', $data['uid']);
     }
@@ -102,7 +102,7 @@ class AttributeTest extends TestCase
         $data = ['uid' => ['old']];
         Attribute::setAttribute($data, 'uid', 'new', false);
         $this->assertArrayHasKey('uid', $data);
-        $this->assertInternalType('array', $data['uid']);
+        $this->assertIsArray($data['uid']);
         $this->assertCount(1, $data['uid']);
         $this->assertContains('new', $data['uid']);
     }
@@ -112,7 +112,7 @@ class AttributeTest extends TestCase
         $data = ['uid' => ['old']];
         Attribute::setAttribute($data, 'uid', 'new', true);
         $this->assertArrayHasKey('uid', $data);
-        $this->assertInternalType('array', $data['uid']);
+        $this->assertIsArray($data['uid']);
         $this->assertCount(2, $data['uid']);
         $this->assertContains('old', $data['uid']);
         $this->assertContains('new', $data['uid']);
@@ -139,7 +139,7 @@ class AttributeTest extends TestCase
         $data = [];
         Attribute::setAttribute($data, 'uid', ['new1', 'new2'], false);
         $this->assertArrayHasKey('uid', $data);
-        $this->assertInternalType('array', $data['uid']);
+        $this->assertIsArray($data['uid']);
         $this->assertCount(2, $data['uid']);
         $this->assertContains('new1', $data['uid']);
         $this->assertContains('new2', $data['uid']);
@@ -152,7 +152,7 @@ class AttributeTest extends TestCase
         $data = ['uid' => ['old']];
         Attribute::setAttribute($data, 'uid', ['new1', 'new2'], false);
         $this->assertArrayHasKey('uid', $data);
-        $this->assertInternalType('array', $data['uid']);
+        $this->assertIsArray($data['uid']);
         $this->assertCount(2, $data['uid']);
         $this->assertContains('new1', $data['uid']);
         $this->assertContains('new2', $data['uid']);
@@ -165,7 +165,7 @@ class AttributeTest extends TestCase
         $data = ['uid' => ['old']];
         Attribute::setAttribute($data, 'uid', ['new1', 'new2'], true);
         $this->assertArrayHasKey('uid', $data);
-        $this->assertInternalType('array', $data['uid']);
+        $this->assertIsArray($data['uid']);
         $this->assertCount(3, $data['uid']);
         $this->assertContains('old', $data['uid']);
         $this->assertContains('new1', $data['uid']);
@@ -329,7 +329,7 @@ class AttributeTest extends TestCase
         $data = ['test' => ['value1', 'value2', 'value3', 'value3']];
         Attribute::removeFromAttribute($data, 'test', 'value2');
         $this->assertArrayHasKey('test', $data);
-        $this->assertInternalType('array', $data['test']);
+        $this->assertIsArray($data['test']);
         $this->assertCount(3, $data['test']);
         $this->assertContains('value1', $data['test']);
         $this->assertContains('value3', $data['test']);
@@ -341,7 +341,7 @@ class AttributeTest extends TestCase
         $data = ['test' => ['value1', 'value2', 'value3', 'value3']];
         Attribute::removeFromAttribute($data, 'test', ['value1', 'value2']);
         $this->assertArrayHasKey('test', $data);
-        $this->assertInternalType('array', $data['test']);
+        $this->assertIsArray($data['test']);
         $this->assertCount(2, $data['test']);
         $this->assertContains('value3', $data['test']);
         $this->assertNotContains('value1', $data['test']);
@@ -353,7 +353,7 @@ class AttributeTest extends TestCase
         $data = ['test' => ['value1', 'value2', 'value3', 'value3']];
         Attribute::removeFromAttribute($data, 'test', 'value3');
         $this->assertArrayHasKey('test', $data);
-        $this->assertInternalType('array', $data['test']);
+        $this->assertIsArray($data['test']);
         $this->assertCount(2, $data['test']);
         $this->assertContains('value1', $data['test']);
         $this->assertContains('value2', $data['test']);
@@ -365,7 +365,7 @@ class AttributeTest extends TestCase
         $data = ['test' => ['value1', 'value2', 'value3', 'value3']];
         Attribute::removeFromAttribute($data, 'test', ['value1', 'value3']);
         $this->assertArrayHasKey('test', $data);
-        $this->assertInternalType('array', $data['test']);
+        $this->assertIsArray($data['test']);
         $this->assertCount(1, $data['test']);
         $this->assertContains('value2', $data['test']);
         $this->assertNotContains('value1', $data['test']);
@@ -377,7 +377,7 @@ class AttributeTest extends TestCase
         $data = ['test' => ['TRUE', 'FALSE', 'TRUE', 'FALSE']];
         Attribute::removeFromAttribute($data, 'test', false);
         $this->assertArrayHasKey('test', $data);
-        $this->assertInternalType('array', $data['test']);
+        $this->assertIsArray($data['test']);
         $this->assertCount(2, $data['test']);
         $this->assertContains('TRUE', $data['test']);
         $this->assertNotContains('FALSE', $data['test']);
@@ -388,7 +388,7 @@ class AttributeTest extends TestCase
         $data = ['test' => ['1', '2', '3', '4']];
         Attribute::removeFromAttribute($data, 'test', [2, 4]);
         $this->assertArrayHasKey('test', $data);
-        $this->assertInternalType('array', $data['test']);
+        $this->assertIsArray($data['test']);
         $this->assertCount(2, $data['test']);
         $this->assertContains('1', $data['test']);
         $this->assertContains('3', $data['test']);

--- a/test/BindTest.php
+++ b/test/BindTest.php
@@ -321,8 +321,8 @@ class BindTest extends TestCase
         // The "pass" expectation here is just that no exception was thrown.
         // Getting to this point in the code is the "definition of pass".
         // phpunit will flag this as a risky test if we do not assert anything,
-        // so assert something.
-        $this->assertIsObject($ldap);
+        // so assert something about the LDAP object.
+        $this->assertEquals(0, $ldap->getLastErrorCode());
     }
 
     /**

--- a/test/BindTest.php
+++ b/test/BindTest.php
@@ -29,7 +29,7 @@ class BindTest extends TestCase
     protected $altUsername;
     protected $bindRequiresDn = false;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! getenv('TESTS_LAMINAS_LDAP_ONLINE_ENABLED')) {
             $this->markTestSkipped("Laminas_Ldap online tests are not enabled");
@@ -79,7 +79,7 @@ class BindTest extends TestCase
             $ldap->bind();
             $this->fail('Expected exception for empty options');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('A host parameter is required', $zle->getMessage());
+            $this->assertStringContainsString('A host parameter is required', $zle->getMessage());
         }
     }
 
@@ -93,7 +93,7 @@ class BindTest extends TestCase
             $ldap->bind();
         } catch (Exception\LdapException $zle) {
             // or I guess the server doesn't allow unauthenticated binds
-            $this->assertContains('unauthenticated bind', $zle->getMessage());
+            $this->assertStringContainsString('unauthenticated bind', $zle->getMessage());
         }
     }
 
@@ -108,7 +108,7 @@ class BindTest extends TestCase
             $ldap->bind('invalid', 'ignored');
             $this->fail('Expected exception for baseDn missing');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('Base DN not set', $zle->getMessage());
+            $this->assertStringContainsString('Base DN not set', $zle->getMessage());
         }
     }
 
@@ -124,7 +124,7 @@ class BindTest extends TestCase
             $ldap->bind('invalid', 'ignored');
             $this->fail('Expected exception for missing accountDomainName');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('Option required: accountDomainName', $zle->getMessage());
+            $this->assertStringContainsString('Option required: accountDomainName', $zle->getMessage());
         }
     }
 
@@ -167,7 +167,7 @@ class BindTest extends TestCase
             $ldap->bind($this->altUsername, 'invalid');
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('Invalid credentials', $zle->getMessage());
+            $this->assertStringContainsString('Invalid credentials', $zle->getMessage());
         }
     }
 
@@ -190,7 +190,7 @@ class BindTest extends TestCase
                 $this->markTestSkipped('Anonymous bind needs to be disallowed for this test');
             }
 
-            $this->assertContains('Failed to retrieve DN', $zle->getMessage());
+            $this->assertStringContainsString('Failed to retrieve DN', $zle->getMessage());
         }
     }
 
@@ -203,7 +203,7 @@ class BindTest extends TestCase
             $ldap->bind($this->altUsername, '');
             $this->fail('Expected exception for empty password');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'Empty password not allowed - see allowEmptyPassword option.',
                 $zle->getMessage()
             );
@@ -238,7 +238,7 @@ class BindTest extends TestCase
             $ldap->bind();
             $this->fail('Expected exception for empty password');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'Binding requires username in DN form',
                 $zle->getMessage()
             );
@@ -271,7 +271,7 @@ class BindTest extends TestCase
     {
         $ldap = new Ldap\Ldap($this->options);
         $this->assertNotNull($ldap->getResource());
-        $this->assertInternalType('resource', $ldap->getResource());
+        $this->assertIsResource($ldap->getResource());
         $this->assertEquals(getenv('TESTS_LAMINAS_LDAP_USERNAME'), $ldap->getBoundUser());
     }
 
@@ -318,6 +318,11 @@ class BindTest extends TestCase
         ];
         $ldap = $this->getSslLdap($options);
         $ldap->bind();
+        // The "pass" expectation here is just that no exception was thrown.
+        // Getting to this point in the code is the "definition of pass".
+        // phpunit will flag this as a risky test if we do not assert anything,
+        // so assert something.
+        $this->assertIsObject($ldap);
     }
 
     /**

--- a/test/CanonTest.php
+++ b/test/CanonTest.php
@@ -28,7 +28,7 @@ class CanonTest extends TestCase
      */
     protected $options;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! getenv('TESTS_LAMINAS_LDAP_ONLINE_ENABLED')) {
             $this->markTestSkipped("Laminas_Ldap online tests are not enabled");
@@ -209,7 +209,7 @@ class CanonTest extends TestCase
             $canon = $ldap->getCanonicalAccountName('invalid', Ldap\Ldap::ACCTNAME_FORM_DN);
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('(&(objectClass=posixAccount)(uid=invalid))', $zle->getMessage());
+            $this->assertStringContainsString('(&(objectClass=posixAccount)(uid=invalid))', $zle->getMessage());
         }
 
         $options['bindRequiresDn'] = false;
@@ -218,7 +218,7 @@ class CanonTest extends TestCase
             $canon = $ldap->getCanonicalAccountName('invalid', Ldap\Ldap::ACCTNAME_FORM_DN);
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('(&(objectClass=user)(sAMAccountName=invalid))', $zle->getMessage());
+            $this->assertStringContainsString('(&(objectClass=user)(sAMAccountName=invalid))', $zle->getMessage());
         }
     }
 
@@ -233,7 +233,7 @@ class CanonTest extends TestCase
             );
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'Binding domain is not an authority for user: invalid\invalid',
                 $zle->getMessage()
             );
@@ -245,7 +245,7 @@ class CanonTest extends TestCase
             );
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'Binding domain is not an authority for user: invalid@invalid.tld',
                 $zle->getMessage()
             );
@@ -265,7 +265,7 @@ class CanonTest extends TestCase
             );
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'Binding domain is not an authority for user: invalid@' .
                     getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME'),
                 $zle->getMessage()
@@ -282,7 +282,7 @@ class CanonTest extends TestCase
             );
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'Binding domain is not an authority for user: ' .
                     getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME_SHORT') . '\invalid',
                 $zle->getMessage()
@@ -321,7 +321,7 @@ class CanonTest extends TestCase
             );
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'Invalid account name syntax: 0@' .
                     getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME'),
                 $zle->getMessage()
@@ -335,7 +335,7 @@ class CanonTest extends TestCase
             );
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'Invalid account name syntax: ' .
                     getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME_SHORT') . '\\0',
                 $zle->getMessage()
@@ -352,7 +352,7 @@ class CanonTest extends TestCase
             $canon = $ldap->getCanonicalAccountName(getenv('TESTS_LAMINAS_LDAP_ALT_USERNAME'), 99);
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'Unknown canonical name form: 99',
                 $zle->getMessage()
             );
@@ -371,7 +371,7 @@ class CanonTest extends TestCase
             );
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'Option required: accountDomainName',
                 $zle->getMessage()
             );
@@ -386,7 +386,7 @@ class CanonTest extends TestCase
             );
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+            $this->assertStringContainsString(
                 'Option required: accountDomainNameShort',
                 $zle->getMessage()
             );

--- a/test/ConnectTest.php
+++ b/test/ConnectTest.php
@@ -25,7 +25,7 @@ class ConnectTest extends TestCase
 {
     protected $options = null;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! getenv('TESTS_LAMINAS_LDAP_ONLINE_ENABLED')) {
             $this->markTestSkipped("Laminas_Ldap online tests are not enabled");
@@ -52,7 +52,7 @@ class ConnectTest extends TestCase
             $ldap->connect();
             $this->fail('Expected exception for empty options');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('host parameter is required', $zle->getMessage());
+            $this->assertStringContainsString('host parameter is required', $zle->getMessage());
         }
     }
 
@@ -91,7 +91,7 @@ class ConnectTest extends TestCase
             $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('Invalid credentials', $zle->getMessage());
+            $this->assertStringContainsString('Invalid credentials', $zle->getMessage());
         }
     }
 
@@ -123,7 +123,7 @@ class ConnectTest extends TestCase
                 ->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('Invalid credentials', $zle->getMessage());
+            $this->assertStringContainsString('Invalid credentials', $zle->getMessage());
         }
     }
 
@@ -143,7 +143,7 @@ class ConnectTest extends TestCase
                 ->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('Invalid credentials', $zle->getMessage());
+            $this->assertStringContainsString('Invalid credentials', $zle->getMessage());
         }
     }
 
@@ -171,7 +171,7 @@ class ConnectTest extends TestCase
             $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for unknown username');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('Can\'t contact LDAP server', $zle->getMessage());
+            $this->assertStringContainsString('Can\'t contact LDAP server', $zle->getMessage());
         }
     }
 
@@ -183,7 +183,7 @@ class ConnectTest extends TestCase
             $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('Invalid credentials', $zle->getMessage());
+            $this->assertStringContainsString('Invalid credentials', $zle->getMessage());
         }
     }
 
@@ -195,7 +195,7 @@ class ConnectTest extends TestCase
                 $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
                 $this->fail('Expected exception for unknown username');
             } catch (Exception\LdapException $zle) {
-                $this->assertContains('Invalid credentials', $zle->getMessage());
+                $this->assertStringContainsString('Invalid credentials', $zle->getMessage());
             }
         }
     }
@@ -209,7 +209,7 @@ class ConnectTest extends TestCase
                 $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
                 $this->fail('Expected exception for unknown username');
             } catch (Exception\LdapException $zle) {
-                $this->assertContains('Invalid credentials', $zle->getMessage());
+                $this->assertStringContainsString('Invalid credentials', $zle->getMessage());
             }
         }
     }
@@ -224,7 +224,7 @@ class ConnectTest extends TestCase
             $ldap->connect()->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('Invalid credentials', $zle->getMessage());
+            $this->assertStringContainsString('Invalid credentials', $zle->getMessage());
 
             $this->assertEquals(0x31, $zle->getCode());
             $this->assertEquals(0x0, $ldap->getLastErrorCode());
@@ -260,7 +260,7 @@ class ConnectTest extends TestCase
                 ->bind('CN=ignored,DC=example,DC=com', 'ignored');
             $this->fail('Expected exception for invalid username');
         } catch (Exception\LdapException $zle) {
-            $this->assertContains('Invalid credentials', $zle->getMessage());
+            $this->assertStringContainsString('Invalid credentials', $zle->getMessage());
         }
     }
 
@@ -270,6 +270,8 @@ class ConnectTest extends TestCase
      */
     public function testConnectionWithoutPortInOptionsArray($host, $ssl, $connectURI)
     {
+        $this->expectException(Exception\LdapException::class);
+        $this->expectExceptionMessage($connectURI);
         $options = [
             'host' => $host,
             'useSsl' => $ssl,
@@ -277,13 +279,16 @@ class ConnectTest extends TestCase
 
         $ldap = new Ldap\Ldap($options);
         $ldap->connect();
-
-        $this->assertAttributeEquals($connectURI, 'connectString', $ldap);
+        // bind should throw the expected exception
+        // The purpose of the test is to see that the $connectURI string is found
+        // in the exception message.
+        $ldap->bind();
     }
 
     public function connectionWithoutPortInOptionsArrayProvider()
     {
-        $host = getenv('TESTS_LAMINAS_LDAP_HOST');
+        // purposely set the host to something invalid so that the test will throw an exception
+        $host = 'unknown';
         return [
             // ['host', 'boolean whether to use LDAPS or not', 'connectionURI'],
             [$host, false, 'ldap://' . $host . ':389'],

--- a/test/ConnectTest.php
+++ b/test/ConnectTest.php
@@ -270,8 +270,6 @@ class ConnectTest extends TestCase
      */
     public function testConnectionWithoutPortInOptionsArray($host, $ssl, $connectURI)
     {
-        $this->expectException(Exception\LdapException::class);
-        $this->expectExceptionMessage($connectURI);
         $options = [
             'host' => $host,
             'useSsl' => $ssl,
@@ -282,6 +280,8 @@ class ConnectTest extends TestCase
         // bind should throw the expected exception
         // The purpose of the test is to see that the $connectURI string is found
         // in the exception message.
+        $this->expectException(Exception\LdapException::class);
+        $this->expectExceptionMessage($connectURI);
         $ldap->bind();
     }
 

--- a/test/Converter/ConverterTest.php
+++ b/test/Converter/ConverterTest.php
@@ -176,7 +176,7 @@ class ConverterTest extends TestCase
 
     public function testFromLdapUnserializeThrowsException()
     {
-        $this->expectException('UnexpectedValueException');
+        $this->expectException(\UnexpectedValueException::class);
         Converter::fromLdapUnserialize('--');
     }
 
@@ -193,7 +193,7 @@ class ConverterTest extends TestCase
     {
         $this->assertTrue(Converter::fromLdapBoolean('TRUE'));
         $this->assertFalse(Converter::fromLdapBoolean('FALSE'));
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         Converter::fromLdapBoolean('test');
     }
 

--- a/test/Converter/ConverterTest.php
+++ b/test/Converter/ConverterTest.php
@@ -229,11 +229,12 @@ class ConverterTest extends TestCase
     }
 
     /**
-     * @expectedException    InvalidArgumentException
+     *
      * @dataProvider         fromLdapDateTimeException
      */
     public function testFromLdapDateTimeThrowsException($value)
     {
+        $this->expectException(\InvalidArgumentException::class);
         Converter::fromLdapDatetime($value);
     }
 

--- a/test/CopyRenameTest.php
+++ b/test/CopyRenameTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Ldap;
 
 use Laminas\Ldap;
+use Laminas\Ldap\Exception\LdapException;
 
 /**
  * @group      Laminas_Ldap
@@ -41,7 +42,7 @@ class CopyRenameTest extends AbstractOnlineTestCase
      */
     private $nodes;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareLDAPServer();
@@ -85,7 +86,7 @@ class CopyRenameTest extends AbstractOnlineTestCase
         }
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (! getenv('TESTS_LAMINAS_LDAP_ONLINE_ENABLED')) {
             return;
@@ -136,51 +137,39 @@ class CopyRenameTest extends AbstractOnlineTestCase
         $this->assertTrue($this->getLDAP()->exists('ou=OrgTest,' . $this->orgSubTreeDn));
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\LdapException
-     */
     public function testRenameSourceNotExists()
     {
+        $this->expectException(LdapException::class);
         $this->getLDAP()->rename($this->createDn('ou=DoesNotExist,'), $this->newDn, false);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\LdapException
-     */
     public function testRenameTargetExists()
     {
+        $this->expectException(LdapException::class);
         $this->getLDAP()->rename($this->orgDn, $this->createDn('ou=Test1,'), false);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\LdapException
-     */
     public function testRenameTargetParentNotExists()
     {
+        $this->expectException(LdapException::class);
         $this->getLDAP()->rename($this->orgDn, $this->createDn('ou=Test1,ou=ParentDoesNotExist,'), false);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\LdapException
-     */
     public function testRenameEmulationSourceNotExists()
     {
+        $this->expectException(LdapException::class);
         $this->getLDAP()->rename($this->createDn('ou=DoesNotExist,'), $this->newDn, false, true);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\LdapException
-     */
     public function testRenameEmulationTargetExists()
     {
+        $this->expectException(LdapException::class);
         $this->getLDAP()->rename($this->orgDn, $this->createDn('ou=Test1,'), false, true);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\LdapException
-     */
     public function testRenameEmulationTargetParentNotExists()
     {
+        $this->expectException(LdapException::class);
         $this->getLDAP()->rename(
             $this->orgDn,
             $this->createDn('ou=Test1,ou=ParentDoesNotExist,'),

--- a/test/CrudTest.php
+++ b/test/CrudTest.php
@@ -102,8 +102,8 @@ class CrudTest extends AbstractOnlineTestCase
         // This test "manually" handles which exceptions are expected where.
         // So it does make any "assert*" calls, and does not set any expected exception.
         // Because of this, phpunit will flag this as a risky test,
-        // so assert something before finishing the test.
-        $this->assertTrue(true);
+        // so assert something about the LDAP object.
+        $this->assertEquals(0, $this->getLDAP()->getLastErrorCode());
     }
 
     public function testIllegalDelete()

--- a/test/CrudTest.php
+++ b/test/CrudTest.php
@@ -10,6 +10,7 @@ namespace LaminasTest\Ldap;
 
 use Laminas\Ldap;
 use Laminas\Ldap\Exception;
+use Laminas\Ldap\Exception\LdapException;
 
 /**
  * @group      Laminas_Ldap
@@ -28,7 +29,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->assertEquals(1, $this->getLDAP()->count('ou=TestCreated'));
             $this->getLDAP()->delete($dn);
             $this->assertEquals(0, $this->getLDAP()->count('ou=TestCreated'));
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -53,7 +54,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLDAP()->getEntry($dn);
             $this->getLDAP()->delete($dn);
             $this->assertEquals('mylocation2', $entry['l'][0]);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -61,11 +62,9 @@ class CrudTest extends AbstractOnlineTestCase
         }
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\LdapException
-     */
     public function testIllegalAdd()
     {
+        $this->expectException(LdapException::class);
         $dn   = $this->createDn('ou=TestCreated,ou=Node2,');
         $data = [
             'ou'          => 'TestCreated',
@@ -90,23 +89,27 @@ class CrudTest extends AbstractOnlineTestCase
             $exThrown = false;
             try {
                 $this->getLDAP()->update($dn, $entry);
-            } catch (Exception\LdapException $e) {
+            } catch (LdapException $e) {
                 $exThrown = true;
             }
             $this->getLDAP()->delete($dn);
             if (! $exThrown) {
                 $this->fail('no exception thrown while illegally updating entry');
             }
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             $this->fail($e->getMessage());
         }
+
+        // This test "manually" handles which exceptions are expected where.
+        // So it does make any "assert*" calls, and does not set any expected exception.
+        // Because of this, phpunit will flag this as a risky test,
+        // so assert something before finishing the test.
+        $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\LdapException
-     */
     public function testIllegalDelete()
     {
+        $this->expectException(LdapException::class);
         $dn = $this->createDn('ou=TestCreated,');
         $this->getLDAP()->delete($dn);
     }
@@ -137,7 +140,7 @@ class CrudTest extends AbstractOnlineTestCase
         $exCaught = false;
         try {
             $this->getLDAP()->delete($topDn, false);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             $exCaught = true;
         }
         $this->assertTrue(
@@ -162,7 +165,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLDAP()->getEntry($dn);
             $this->getLDAP()->delete($dn);
             $this->assertEquals('mylocation1', $entry['l'][0]);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -225,21 +228,17 @@ class CrudTest extends AbstractOnlineTestCase
         $this->assertEquals($expected, $data);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testPrepareLDAPEntryArrayArrayData()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $data = [
             'a1' => [['account']]];
         Ldap\Ldap::prepareLDAPEntryArray($data);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testPrepareLDAPEntryArrayObjectData()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $class    = new \stdClass();
         $class->a = 'b';
         $data     = [
@@ -258,7 +257,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->getLDAP()->add($dn, $data);
             $this->assertEquals(1, $this->getLDAP()->count('ou=TestCreated'));
             $this->getLDAP()->delete($dn);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             $this->fail($e->getMessage());
         }
     }
@@ -280,7 +279,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLDAP()->getEntry($dn);
             $this->getLDAP()->delete($dn);
             $this->assertEquals('mylocation2', $entry['l'][0]);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             $this->fail($e->getMessage());
         }
     }
@@ -299,7 +298,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLDAP()->getEntry($dn);
             $this->getLDAP()->delete($dn);
             $this->assertEquals('mylocation1', $entry['l'][0]);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -327,7 +326,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->assertEquals('domain', $entry['associateddomain'][0]);
             $this->assertContains('organizationalUnit', $entry['objectclass']);
             $this->assertContains('domainRelatedObject', $entry['objectclass']);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -356,7 +355,7 @@ class CrudTest extends AbstractOnlineTestCase
             $this->assertArrayNotHasKey('associateddomain', $entry);
             $this->assertContains('organizationalUnit', $entry['objectclass']);
             $this->assertNotContains('domainRelatedObject', $entry['objectclass']);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             if ($this->getLDAP()->exists($dn)) {
                 $this->getLDAP()->delete($dn);
             }
@@ -378,7 +377,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLdap()->getEntry($dn);
             $this->getLdap()->delete($dn);
             $this->assertEquals(['TestCreated'], $entry['ou']);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             if ($this->getLdap()->exists($dn)) {
                 $this->getLdap()->delete($dn);
             }
@@ -401,7 +400,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLdap()->getEntry($dn);
             $this->getLdap()->delete($dn);
             $this->assertEquals(['TestCreated', 'SecondOu'], $entry['ou']);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             if ($this->getLdap()->exists($dn)) {
                 $this->getLdap()->delete($dn);
             }
@@ -424,7 +423,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLdap()->getEntry($dn);
             $this->getLdap()->delete($dn);
             $this->assertEquals(['TestCreated', 'SecondOu'], $entry['ou']);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             if ($this->getLdap()->exists($dn)) {
                 $this->getLdap()->delete($dn);
             }
@@ -451,7 +450,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLdap()->getEntry($dn);
             $this->getLdap()->delete($dn);
             $this->assertEquals(['TestCreated', 'SecondOu'], $entry['ou']);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             if ($this->getLdap()->exists($dn)) {
                 $this->getLdap()->delete($dn);
             }
@@ -478,7 +477,7 @@ class CrudTest extends AbstractOnlineTestCase
             $entry = $this->getLdap()->getEntry($dn);
             $this->getLdap()->delete($dn);
             $this->assertEquals(['TestCreated', 'SecondOu'], $entry['ou']);
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             if ($this->getLdap()->exists($dn)) {
                 $this->getLdap()->delete($dn);
             }

--- a/test/CrudTest.php
+++ b/test/CrudTest.php
@@ -64,14 +64,13 @@ class CrudTest extends AbstractOnlineTestCase
 
     public function testIllegalAdd()
     {
-        $this->expectException(LdapException::class);
         $dn   = $this->createDn('ou=TestCreated,ou=Node2,');
         $data = [
             'ou'          => 'TestCreated',
             'objectClass' => 'organizationalUnit'
         ];
+        $this->expectException(LdapException::class);
         $this->getLDAP()->add($dn, $data);
-        $this->getLDAP()->delete($dn);
     }
 
     public function testIllegalUpdate()
@@ -109,8 +108,8 @@ class CrudTest extends AbstractOnlineTestCase
 
     public function testIllegalDelete()
     {
-        $this->expectException(LdapException::class);
         $dn = $this->createDn('ou=TestCreated,');
+        $this->expectException(LdapException::class);
         $this->getLDAP()->delete($dn);
     }
 
@@ -230,19 +229,19 @@ class CrudTest extends AbstractOnlineTestCase
 
     public function testPrepareLDAPEntryArrayArrayData()
     {
-        $this->expectException(\InvalidArgumentException::class);
         $data = [
             'a1' => [['account']]];
+        $this->expectException(\InvalidArgumentException::class);
         Ldap\Ldap::prepareLDAPEntryArray($data);
     }
 
     public function testPrepareLDAPEntryArrayObjectData()
     {
-        $this->expectException(\InvalidArgumentException::class);
         $class    = new \stdClass();
         $class->a = 'b';
         $data     = [
             'a1' => [$class]];
+        $this->expectException(\InvalidArgumentException::class);
         Ldap\Ldap::prepareLDAPEntryArray($data);
     }
 

--- a/test/Dn/ExplodingTest.php
+++ b/test/Dn/ExplodingTest.php
@@ -195,8 +195,8 @@ class ExplodingTest extends TestCase
 
     public function testCreateDnArrayIllegalDn()
     {
-        $this->expectException(LdapException::class);
         $dn      = 'name1,cn=name2,dc=example,dc=org';
+        $this->expectException(LdapException::class);
         $dnArray = Ldap\Dn::explodeDn($dn);
     }
 

--- a/test/Dn/ExplodingTest.php
+++ b/test/Dn/ExplodingTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Ldap\Dn;
 
 use Laminas\Ldap;
+use Laminas\Ldap\Exception\LdapException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -192,11 +193,9 @@ class ExplodingTest extends TestCase
         $this->assertEquals($expected, $dnArray);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testCreateDnArrayIllegalDn()
     {
+        $this->expectException(LdapException::class);
         $dn      = 'name1,cn=name2,dc=example,dc=org';
         $dnArray = Ldap\Dn::explodeDn($dn);
     }

--- a/test/Dn/ImplodingTest.php
+++ b/test/Dn/ImplodingTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Ldap\Dn;
 
 use Laminas\Ldap;
+use Laminas\Ldap\Exception\LdapException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -113,20 +114,16 @@ class ImplodingTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testImplodeRdnInvalidOne()
     {
+        $this->expectException(LdapException::class);
         $a = ['cn'];
         Ldap\Dn::implodeRdn($a);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testImplodeRdnInvalidThree()
     {
+        $this->expectException(LdapException::class);
         $a = ['cn' => 'value', 'ou'];
         Ldap\Dn::implodeRdn($a);
     }

--- a/test/Dn/ImplodingTest.php
+++ b/test/Dn/ImplodingTest.php
@@ -116,15 +116,15 @@ class ImplodingTest extends TestCase
 
     public function testImplodeRdnInvalidOne()
     {
-        $this->expectException(LdapException::class);
         $a = ['cn'];
+        $this->expectException(LdapException::class);
         Ldap\Dn::implodeRdn($a);
     }
 
     public function testImplodeRdnInvalidThree()
     {
-        $this->expectException(LdapException::class);
         $a = ['cn' => 'value', 'ou'];
+        $this->expectException(LdapException::class);
         Ldap\Dn::implodeRdn($a);
     }
 }

--- a/test/ErrorHandlerTest.php
+++ b/test/ErrorHandlerTest.php
@@ -18,18 +18,8 @@ class ErrorHandlerTest extends TestCase
 {
     protected $dummyErrorHandler;
 
-    protected $currentErrorHandler = [
-        \PHPUnit\Util\ErrorHandler::class,
-        'handleError',
-    ];
-
-    protected function setUp()
+    protected function setUp(): void
     {
-        /** @todo: remove when migrate to PHP 7.1+ and PHPUnit 7+ only */
-        if (class_exists(\PHPUnit_Util_ErrorHandler::class)) {
-            $this->currentErrorHandler[0] = \PHPUnit_Util_ErrorHandler::class;
-        }
-
         $this->dummyErrorHandler = function ($errno, $error) {
         };
     }
@@ -37,21 +27,29 @@ class ErrorHandlerTest extends TestCase
     {
         $errorHandler = new ErrorHandler();
 
-        $this->assertEquals($this->currentErrorHandler, set_error_handler($this->dummyErrorHandler));
+        $returnValue1 = set_error_handler($this->dummyErrorHandler);
+        $this->assertIsObject($returnValue1);
+        $this->assertInstanceOf('\PHPUnit\Util\ErrorHandler', $returnValue1);
         $errorHandler->startErrorHandling();
-        $this->assertEquals($this->dummyErrorHandler, set_error_handler($this->dummyErrorHandler));
+        $returnValue2 = set_error_handler($this->dummyErrorHandler);
+        $this->assertIsObject($returnValue2);
+        $this->assertInstanceOf('\Closure', $returnValue2);
 
         restore_error_handler();
         restore_error_handler();
     }
 
-    public function testErrorHandlerREmovalWorks()
+    public function testErrorHandlerRemovalWorks()
     {
         $errorHandler = new ErrorHandler();
 
-        $this->assertEquals($this->currentErrorHandler, set_error_handler($this->dummyErrorHandler));
+        $returnValue1 = set_error_handler($this->dummyErrorHandler);
+        $this->assertIsObject($returnValue1);
+        $this->assertInstanceOf('\PHPUnit\Util\ErrorHandler', $returnValue1);
         $errorHandler->stopErrorHandling();
-        $this->assertEquals($this->currentErrorHandler, set_error_handler($this->dummyErrorHandler));
+        $returnValue2 = set_error_handler($this->dummyErrorHandler);
+        $this->assertIsObject($returnValue2);
+        $this->assertInstanceOf('\PHPUnit\Util\ErrorHandler', $returnValue2);
 
         restore_error_handler();
     }

--- a/test/ErrorHandlerTest.php
+++ b/test/ErrorHandlerTest.php
@@ -29,11 +29,11 @@ class ErrorHandlerTest extends TestCase
 
         $returnValue1 = set_error_handler($this->dummyErrorHandler);
         $this->assertIsObject($returnValue1);
-        $this->assertInstanceOf('\PHPUnit\Util\ErrorHandler', $returnValue1);
+        $this->assertInstanceOf(\PHPUnit\Util\ErrorHandler::class, $returnValue1);
         $errorHandler->startErrorHandling();
         $returnValue2 = set_error_handler($this->dummyErrorHandler);
         $this->assertIsObject($returnValue2);
-        $this->assertInstanceOf('\Closure', $returnValue2);
+        $this->assertInstanceOf(\Closure::class, $returnValue2);
 
         restore_error_handler();
         restore_error_handler();
@@ -45,11 +45,11 @@ class ErrorHandlerTest extends TestCase
 
         $returnValue1 = set_error_handler($this->dummyErrorHandler);
         $this->assertIsObject($returnValue1);
-        $this->assertInstanceOf('\PHPUnit\Util\ErrorHandler', $returnValue1);
+        $this->assertInstanceOf(\PHPUnit\Util\ErrorHandler::class, $returnValue1);
         $errorHandler->stopErrorHandling();
         $returnValue2 = set_error_handler($this->dummyErrorHandler);
         $this->assertIsObject($returnValue2);
-        $this->assertInstanceOf('\PHPUnit\Util\ErrorHandler', $returnValue2);
+        $this->assertInstanceOf(\PHPUnit\Util\ErrorHandler::class, $returnValue2);
 
         restore_error_handler();
     }

--- a/test/FilterTest.php
+++ b/test/FilterTest.php
@@ -10,6 +10,7 @@ namespace LaminasTest\Ldap;
 
 use Laminas\Ldap;
 use Laminas\Ldap\Filter;
+use Laminas\Ldap\Filter\Exception\FilterException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -100,11 +101,9 @@ class FilterTest extends TestCase
         $this->assertEquals('(name=*value)', $f1->toString());
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Filter\Exception\FilterException
-     */
     public function testIllegalGroupingFilter()
     {
+        $this->expectException(FilterException::class);
         $data = ['a', 'b', 5];
         $f    = new Filter\AndFilter($data);
     }

--- a/test/FilterTest.php
+++ b/test/FilterTest.php
@@ -103,8 +103,8 @@ class FilterTest extends TestCase
 
     public function testIllegalGroupingFilter()
     {
-        $this->expectException(FilterException::class);
         $data = ['a', 'b', 5];
+        $this->expectException(FilterException::class);
         $f    = new Filter\AndFilter($data);
     }
 

--- a/test/Node/ChildrenIterationTest.php
+++ b/test/Node/ChildrenIterationTest.php
@@ -17,13 +17,13 @@ use LaminasTest\Ldap as TestLdap;
  */
 class ChildrenIterationTest extends TestLdap\AbstractOnlineTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareLDAPServer();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->cleanupLDAPServer();
         parent::tearDown();
@@ -94,5 +94,10 @@ class ChildrenIterationTest extends TestLdap\AbstractOnlineTestCase
             // do nothing - just iterate
         }
         $nodes->next();
+        // The "pass" expectation here is just that no exception was thrown.
+        // Getting to this point in the code is the "definition of pass".
+        // phpunit will flag this as a risky test if we do not assert anything,
+        // so assert something.
+        $this->assertIsObject($nodes);
     }
 }

--- a/test/Node/ChildrenIterationTest.php
+++ b/test/Node/ChildrenIterationTest.php
@@ -94,10 +94,6 @@ class ChildrenIterationTest extends TestLdap\AbstractOnlineTestCase
             // do nothing - just iterate
         }
         $nodes->next();
-        // The "pass" expectation here is just that no exception was thrown.
-        // Getting to this point in the code is the "definition of pass".
-        // phpunit will flag this as a risky test if we do not assert anything,
-        // so assert something.
-        $this->assertIsObject($nodes);
+        $this->assertInstanceOf(\Laminas\Ldap\Node::class, $nodes->current());
     }
 }

--- a/test/Node/ChildrenTest.php
+++ b/test/Node/ChildrenTest.php
@@ -16,13 +16,13 @@ use LaminasTest\Ldap as TestLdap;
  */
 class ChildrenTest extends TestLdap\AbstractOnlineTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareLDAPServer();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->cleanupLDAPServer();
         parent::tearDown();

--- a/test/Node/OfflineTest.php
+++ b/test/Node/OfflineTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Ldap\Node;
 
 use Laminas\Ldap;
+use Laminas\Ldap\Exception\LdapException;
 use LaminasTest\Ldap as TestLdap;
 
 /**
@@ -58,31 +59,25 @@ class OfflineTest extends TestLdap\AbstractTestCase
         $this->assertFalse($node->isAttached());
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testCreateFromArrayMissingDn()
     {
+        $this->expectException(LdapException::class);
         $data = $this->createTestArrayData();
         unset($data['dn']);
         $node = Ldap\Node::fromArray($data);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testCreateFromArrayIllegalDn()
     {
+        $this->expectException(LdapException::class);
         $data       = $this->createTestArrayData();
         $data['dn'] = 5;
         $node       = Ldap\Node::fromArray($data);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testCreateFromArrayMalformedDn()
     {
+        $this->expectException(LdapException::class);
         $data       = $this->createTestArrayData();
         $data['dn'] = 'name1,cn=name2,dc=example,dc=org';
         $node       = Ldap\Node::fromArray($data);
@@ -311,20 +306,16 @@ class OfflineTest extends TestLdap\AbstractTestCase
         $this->assertFalse(isset($node->key));
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testIllegalAttributeAccessRdnAttributeSet()
     {
+        $this->expectException(LdapException::class);
         $node     = $this->createTestNode();
         $node->cn = 'test';
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testIllegalAttributeAccessDnSet()
     {
+        $this->expectException(LdapException::class);
         $node     = $this->createTestNode();
         $node->dn = 'test';
     }
@@ -332,7 +323,7 @@ class OfflineTest extends TestLdap\AbstractTestCase
     public function testAttributeAccessDnGet()
     {
         $node = $this->createTestNode();
-        $this->assertInternalType('string', $node->dn);
+        $this->assertIsString($node->dn);
         $this->assertEquals($node->getDn()->toString(), $node->dn);
     }
 

--- a/test/Node/OfflineTest.php
+++ b/test/Node/OfflineTest.php
@@ -61,25 +61,25 @@ class OfflineTest extends TestLdap\AbstractTestCase
 
     public function testCreateFromArrayMissingDn()
     {
-        $this->expectException(LdapException::class);
         $data = $this->createTestArrayData();
         unset($data['dn']);
+        $this->expectException(LdapException::class);
         $node = Ldap\Node::fromArray($data);
     }
 
     public function testCreateFromArrayIllegalDn()
     {
-        $this->expectException(LdapException::class);
         $data       = $this->createTestArrayData();
         $data['dn'] = 5;
+        $this->expectException(LdapException::class);
         $node       = Ldap\Node::fromArray($data);
     }
 
     public function testCreateFromArrayMalformedDn()
     {
-        $this->expectException(LdapException::class);
         $data       = $this->createTestArrayData();
         $data['dn'] = 'name1,cn=name2,dc=example,dc=org';
+        $this->expectException(LdapException::class);
         $node       = Ldap\Node::fromArray($data);
     }
 
@@ -308,15 +308,15 @@ class OfflineTest extends TestLdap\AbstractTestCase
 
     public function testIllegalAttributeAccessRdnAttributeSet()
     {
-        $this->expectException(LdapException::class);
         $node     = $this->createTestNode();
+        $this->expectException(LdapException::class);
         $node->cn = 'test';
     }
 
     public function testIllegalAttributeAccessDnSet()
     {
-        $this->expectException(LdapException::class);
         $node     = $this->createTestNode();
+        $this->expectException(LdapException::class);
         $node->dn = 'test';
     }
 

--- a/test/Node/OnlineTest.php
+++ b/test/Node/OnlineTest.php
@@ -78,8 +78,8 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
 
     public function testLoadFromLDAPIllegalEntry()
     {
-        $this->expectException(ExceptionInterface::class);
         $dn   = $this->createDn('ou=Test99,');
+        $this->expectException(ExceptionInterface::class);
         $node = Ldap\Node::fromLDAP($dn, $this->getLDAP());
     }
 
@@ -108,7 +108,6 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
 
     public function testAttachToInvalidLDAP()
     {
-        $this->expectException(ExceptionInterface::class);
         $data = [
             'dn'          => 'ou=name,dc=example,dc=org',
             'ou'          => ['name'],
@@ -117,6 +116,7 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
         ];
         $node = Ldap\Node::fromArray($data);
         $this->assertFalse($node->isAttached());
+        $this->expectException(ExceptionInterface::class);
         $node->attachLDAP($this->getLDAP());
     }
 
@@ -169,8 +169,8 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
 
     public function testGetIllegalNode()
     {
-        $this->expectException(ExceptionInterface::class);
         $dn   = $this->createDn('ou=Test99,');
+        $this->expectException(ExceptionInterface::class);
         $node = $this->getLDAP()->getNode($dn);
     }
 
@@ -255,8 +255,8 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
 
     public function testGetNonexistentParent()
     {
-        $this->expectException(ExceptionInterface::class);
         $node  = $this->getLDAP()->getNode(getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'));
+        $this->expectException(ExceptionInterface::class);
         $pnode = $node->getParent();
     }
 

--- a/test/Node/OnlineTest.php
+++ b/test/Node/OnlineTest.php
@@ -10,6 +10,7 @@ namespace LaminasTest\Ldap\Node;
 
 use Laminas\Ldap;
 use Laminas\Ldap\Exception;
+use Laminas\Ldap\Exception\ExceptionInterface;
 use LaminasTest\Ldap as TestLdap;
 
 /**
@@ -18,13 +19,13 @@ use LaminasTest\Ldap as TestLdap;
  */
 class OnlineTest extends TestLdap\AbstractOnlineTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareLDAPServer();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->cleanupLDAPServer();
         parent::tearDown();
@@ -44,25 +45,25 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
         try {
             $node->setAttribute('createTimestamp', false);
             $this->fail('Expected exception for modification of read-only attribute createTimestamp');
-        } catch (Exception\ExceptionInterface $e) {
+        } catch (ExceptionInterface $e) {
             $this->assertEquals('Cannot change attribute because it\'s read-only', $e->getMessage());
         }
         try {
             $node->createTimestamp = false;
             $this->fail('Expected exception for modification of read-only attribute createTimestamp');
-        } catch (Exception\ExceptionInterface $e) {
+        } catch (ExceptionInterface $e) {
             $this->assertEquals('Cannot change attribute because it\'s read-only', $e->getMessage());
         }
         try {
             $node['createTimestamp'] = false;
             $this->fail('Expected exception for modification of read-only attribute createTimestamp');
-        } catch (Exception\ExceptionInterface $e) {
+        } catch (ExceptionInterface $e) {
             $this->assertEquals('Cannot change attribute because it\'s read-only', $e->getMessage());
         }
         try {
             $node->appendToAttribute('createTimestamp', 'value');
             $this->fail('Expected exception for modification of read-only attribute createTimestamp');
-        } catch (Exception\ExceptionInterface $e) {
+        } catch (ExceptionInterface $e) {
             $this->assertEquals('Cannot change attribute because it\'s read-only', $e->getMessage());
         }
         try {
@@ -70,16 +71,14 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
             $attr = key($rdn);
             $node->deleteAttribute($attr);
             $this->fail('Expected exception for modification of read-only attribute ' . $attr);
-        } catch (Exception\ExceptionInterface $e) {
+        } catch (ExceptionInterface $e) {
             $this->assertEquals('Cannot change attribute because it\'s part of the RDN', $e->getMessage());
         }
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testLoadFromLDAPIllegalEntry()
     {
+        $this->expectException(ExceptionInterface::class);
         $dn   = $this->createDn('ou=Test99,');
         $node = Ldap\Node::fromLDAP($dn, $this->getLDAP());
     }
@@ -107,11 +106,9 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
         $this->assertEquals($sdata, serialize($newObject));
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testAttachToInvalidLDAP()
     {
+        $this->expectException(ExceptionInterface::class);
         $data = [
             'dn'          => 'ou=name,dc=example,dc=org',
             'ou'          => ['name'],
@@ -170,11 +167,9 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
         $this->assertEquals("Test1", $node->getAttribute('ou', 0));
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testGetIllegalNode()
     {
+        $this->expectException(ExceptionInterface::class);
         $dn   = $this->createDn('ou=Test99,');
         $node = $this->getLDAP()->getNode($dn);
     }
@@ -258,11 +253,9 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
         );
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\ExceptionInterface
-     */
     public function testGetNonexistentParent()
     {
+        $this->expectException(ExceptionInterface::class);
         $node  = $this->getLDAP()->getNode(getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'));
         $pnode = $node->getParent();
     }

--- a/test/Node/RootDseTest.php
+++ b/test/Node/RootDseTest.php
@@ -30,38 +30,38 @@ class RootDseTest extends TestLdap\AbstractOnlineTestCase
     {
         $root = $this->getLDAP()->getRootDse();
 
-        $this->assertInternalType('boolean', $root->supportsSaslMechanism('GSSAPI'));
-        $this->assertInternalType('boolean', $root->supportsSaslMechanism(['GSSAPI', 'DIGEST-MD5']));
-        $this->assertInternalType('boolean', $root->supportsVersion('3'));
-        $this->assertInternalType('boolean', $root->supportsVersion(3));
-        $this->assertInternalType('boolean', $root->supportsVersion(['3', '2']));
-        $this->assertInternalType('boolean', $root->supportsVersion([3, 2]));
+        $this->assertIsBool($root->supportsSaslMechanism('GSSAPI'));
+        $this->assertIsBool($root->supportsSaslMechanism(['GSSAPI', 'DIGEST-MD5']));
+        $this->assertIsBool($root->supportsVersion('3'));
+        $this->assertIsBool($root->supportsVersion(3));
+        $this->assertIsBool($root->supportsVersion(['3', '2']));
+        $this->assertIsBool($root->supportsVersion([3, 2]));
 
         switch ($root->getServerType()) {
             case Node\RootDse::SERVER_TYPE_ACTIVEDIRECTORY:
-                $this->assertInternalType('boolean', $root->supportsControl('1.2.840.113556.1.4.319'));
-                $this->assertInternalType('boolean', $root->supportsControl(['1.2.840.113556.1.4.319',
+                $this->assertIsBool($root->supportsControl('1.2.840.113556.1.4.319'));
+                $this->assertIsBool($root->supportsControl(['1.2.840.113556.1.4.319',
                                                                                  '1.2.840.113556.1.4.473']));
-                $this->assertInternalType('boolean', $root->supportsCapability('1.3.6.1.4.1.4203.1.9.1.1'));
-                $this->assertInternalType('boolean', $root->supportsCapability(['1.3.6.1.4.1.4203.1.9.1.1',
+                $this->assertIsBool($root->supportsCapability('1.3.6.1.4.1.4203.1.9.1.1'));
+                $this->assertIsBool($root->supportsCapability(['1.3.6.1.4.1.4203.1.9.1.1',
                                                                                     '2.16.840.1.113730.3.4.18']));
-                $this->assertInternalType('boolean', $root->supportsPolicy('unknown'));
-                $this->assertInternalType('boolean', $root->supportsPolicy(['unknown', 'unknown']));
+                $this->assertIsBool($root->supportsPolicy('unknown'));
+                $this->assertIsBool($root->supportsPolicy(['unknown', 'unknown']));
                 break;
             case Node\RootDse::SERVER_TYPE_EDIRECTORY:
-                $this->assertInternalType('boolean', $root->supportsExtension('1.3.6.1.4.1.1466.20037'));
-                $this->assertInternalType('boolean', $root->supportsExtension(['1.3.6.1.4.1.1466.20037',
+                $this->assertIsBool($root->supportsExtension('1.3.6.1.4.1.1466.20037'));
+                $this->assertIsBool($root->supportsExtension(['1.3.6.1.4.1.1466.20037',
                                                                                    '1.3.6.1.4.1.4203.1.11.1']));
                 break;
             case Node\RootDse::SERVER_TYPE_OPENLDAP:
-                $this->assertInternalType('boolean', $root->supportsControl('1.3.6.1.4.1.4203.1.9.1.1'));
-                $this->assertInternalType('boolean', $root->supportsControl(['1.3.6.1.4.1.4203.1.9.1.1',
+                $this->assertIsBool($root->supportsControl('1.3.6.1.4.1.4203.1.9.1.1'));
+                $this->assertIsBool($root->supportsControl(['1.3.6.1.4.1.4203.1.9.1.1',
                                                                                  '2.16.840.1.113730.3.4.18']));
-                $this->assertInternalType('boolean', $root->supportsExtension('1.3.6.1.4.1.1466.20037'));
-                $this->assertInternalType('boolean', $root->supportsExtension(['1.3.6.1.4.1.1466.20037',
+                $this->assertIsBool($root->supportsExtension('1.3.6.1.4.1.1466.20037'));
+                $this->assertIsBool($root->supportsExtension(['1.3.6.1.4.1.1466.20037',
                                                                                    '1.3.6.1.4.1.4203.1.11.1']));
-                $this->assertInternalType('boolean', $root->supportsFeature('1.3.6.1.1.14'));
-                $this->assertInternalType('boolean', $root->supportsFeature(['1.3.6.1.1.14',
+                $this->assertIsBool($root->supportsFeature('1.3.6.1.1.14'));
+                $this->assertIsBool($root->supportsFeature(['1.3.6.1.1.14',
                                                                                  '1.3.6.1.4.1.4203.1.5.1']));
                 break;
         }
@@ -71,38 +71,38 @@ class RootDseTest extends TestLdap\AbstractOnlineTestCase
     {
         $root = $this->getLDAP()->getRootDse();
 
-        $this->assertInternalType('array', $root->getNamingContexts());
-        $this->assertInternalType('string', $root->getSubschemaSubentry());
+        $this->assertIsArray($root->getNamingContexts());
+        $this->assertIsString($root->getSubschemaSubentry());
 
         switch ($root->getServerType()) {
             case Node\RootDse::SERVER_TYPE_ACTIVEDIRECTORY:
-                $this->assertInternalType('string', $root->getConfigurationNamingContext());
-                $this->assertInternalType('string', $root->getCurrentTime());
-                $this->assertInternalType('string', $root->getDefaultNamingContext());
-                $this->assertInternalType('string', $root->getDnsHostName());
-                $this->assertInternalType('string', $root->getDomainControllerFunctionality());
-                $this->assertInternalType('string', $root->getDomainFunctionality());
-                $this->assertInternalType('string', $root->getDsServiceName());
-                $this->assertInternalType('string', $root->getForestFunctionality());
-                $this->assertInternalType('string', $root->getHighestCommittedUSN());
-                $this->assertInternalType('boolean', $root->getIsGlobalCatalogReady());
-                $this->assertInternalType('boolean', $root->getIsSynchronized());
-                $this->assertInternalType('string', $root->getLDAPServiceName());
-                $this->assertInternalType('string', $root->getRootDomainNamingContext());
-                $this->assertInternalType('string', $root->getSchemaNamingContext());
-                $this->assertInternalType('string', $root->getServerName());
+                $this->assertIsString($root->getConfigurationNamingContext());
+                $this->assertIsString($root->getCurrentTime());
+                $this->assertIsString($root->getDefaultNamingContext());
+                $this->assertIsString($root->getDnsHostName());
+                $this->assertIsString($root->getDomainControllerFunctionality());
+                $this->assertIsString($root->getDomainFunctionality());
+                $this->assertIsString($root->getDsServiceName());
+                $this->assertIsString($root->getForestFunctionality());
+                $this->assertIsString($root->getHighestCommittedUSN());
+                $this->assertIsBool($root->getIsGlobalCatalogReady());
+                $this->assertIsBool($root->getIsSynchronized());
+                $this->assertIsString($root->getLDAPServiceName());
+                $this->assertIsString($root->getRootDomainNamingContext());
+                $this->assertIsString($root->getSchemaNamingContext());
+                $this->assertIsString($root->getServerName());
                 break;
             case Node\RootDse::SERVER_TYPE_EDIRECTORY:
-                $this->assertInternalType('string', $root->getVendorName());
-                $this->assertInternalType('string', $root->getVendorVersion());
-                $this->assertInternalType('string', $root->getDsaName());
-                $this->assertInternalType('string', $root->getStatisticsErrors());
-                $this->assertInternalType('string', $root->getStatisticsSecurityErrors());
-                $this->assertInternalType('string', $root->getStatisticsChainings());
-                $this->assertInternalType('string', $root->getStatisticsReferralsReturned());
-                $this->assertInternalType('string', $root->getStatisticsExtendedOps());
-                $this->assertInternalType('string', $root->getStatisticsAbandonOps());
-                $this->assertInternalType('string', $root->getStatisticsWholeSubtreeSearchOps());
+                $this->assertIsString($root->getVendorName());
+                $this->assertIsString($root->getVendorVersion());
+                $this->assertIsString($root->getDsaName());
+                $this->assertIsString($root->getStatisticsErrors());
+                $this->assertIsString($root->getStatisticsSecurityErrors());
+                $this->assertIsString($root->getStatisticsChainings());
+                $this->assertIsString($root->getStatisticsReferralsReturned());
+                $this->assertIsString($root->getStatisticsExtendedOps());
+                $this->assertIsString($root->getStatisticsAbandonOps());
+                $this->assertIsString($root->getStatisticsWholeSubtreeSearchOps());
                 break;
             case Node\RootDse::SERVER_TYPE_OPENLDAP:
                 $this->assertNullOrString($root->getConfigContext());
@@ -116,42 +116,34 @@ class RootDseTest extends TestLdap\AbstractOnlineTestCase
         if ($value === null) {
             $this->assertNull($value);
         } else {
-            $this->assertInternalType('string', $value);
+            $this->assertIsString($value);
         }
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testSetterWillThrowException()
     {
+        $this->expectException(\BadMethodCallException::class);
         $root              = $this->getLDAP()->getRootDse();
         $root->objectClass = 'illegal';
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testOffsetSetWillThrowException()
     {
+        $this->expectException(\BadMethodCallException::class);
         $root                = $this->getLDAP()->getRootDse();
         $root['objectClass'] = 'illegal';
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testUnsetterWillThrowException()
     {
+        $this->expectException(\BadMethodCallException::class);
         $root = $this->getLDAP()->getRootDse();
         unset($root->objectClass);
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testOffsetUnsetWillThrowException()
     {
+        $this->expectException(\BadMethodCallException::class);
         $root = $this->getLDAP()->getRootDse();
         unset($root['objectClass']);
     }

--- a/test/Node/RootDseTest.php
+++ b/test/Node/RootDseTest.php
@@ -122,29 +122,29 @@ class RootDseTest extends TestLdap\AbstractOnlineTestCase
 
     public function testSetterWillThrowException()
     {
-        $this->expectException(\BadMethodCallException::class);
         $root              = $this->getLDAP()->getRootDse();
+        $this->expectException(\BadMethodCallException::class);
         $root->objectClass = 'illegal';
     }
 
     public function testOffsetSetWillThrowException()
     {
-        $this->expectException(\BadMethodCallException::class);
         $root                = $this->getLDAP()->getRootDse();
+        $this->expectException(\BadMethodCallException::class);
         $root['objectClass'] = 'illegal';
     }
 
     public function testUnsetterWillThrowException()
     {
-        $this->expectException(\BadMethodCallException::class);
         $root = $this->getLDAP()->getRootDse();
+        $this->expectException(\BadMethodCallException::class);
         unset($root->objectClass);
     }
 
     public function testOffsetUnsetWillThrowException()
     {
-        $this->expectException(\BadMethodCallException::class);
         $root = $this->getLDAP()->getRootDse();
+        $this->expectException(\BadMethodCallException::class);
         unset($root['objectClass']);
     }
 }

--- a/test/Node/SchemaTest.php
+++ b/test/Node/SchemaTest.php
@@ -22,7 +22,7 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
      */
     private $schema;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->schema = $this->getLDAP()->getSchema();
@@ -43,8 +43,8 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
 
     public function testGetters()
     {
-        $this->assertInternalType('array', $this->schema->getAttributeTypes());
-        $this->assertInternalType('array', $this->schema->getObjectClasses());
+        $this->assertIsArray($this->schema->getAttributeTypes());
+        $this->assertIsArray($this->schema->getObjectClasses());
 
         switch ($this->getLDAP()->getRootDse()->getServerType()) {
             case Node\RootDse::SERVER_TYPE_ACTIVEDIRECTORY:
@@ -52,42 +52,34 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
             case Node\RootDse::SERVER_TYPE_EDIRECTORY:
                 break;
             case Node\RootDse::SERVER_TYPE_OPENLDAP:
-                $this->assertInternalType('array', $this->schema->getLDAPSyntaxes());
-                $this->assertInternalType('array', $this->schema->getMatchingRules());
-                $this->assertInternalType('array', $this->schema->getMatchingRuleUse());
+                $this->assertIsArray($this->schema->getLDAPSyntaxes());
+                $this->assertIsArray($this->schema->getMatchingRules());
+                $this->assertIsArray($this->schema->getMatchingRuleUse());
                 break;
         }
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testSetterWillThrowException()
     {
+        $this->expectException(\BadMethodCallException::class);
         $this->schema->objectClass = 'illegal';
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testOffsetSetWillThrowException()
     {
+        $this->expectException(\BadMethodCallException::class);
         $this->schema['objectClass'] = 'illegal';
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testUnsetterWillThrowException()
     {
+        $this->expectException(\BadMethodCallException::class);
         unset($this->schema->objectClass);
     }
 
-    /**
-     * @expectedException BadMethodCallException
-     */
     public function testOffsetUnsetWillThrowException()
     {
+        $this->expectException(\BadMethodCallException::class);
         unset($this->schema['objectClass']);
     }
 

--- a/test/Node/UpdateTest.php
+++ b/test/Node/UpdateTest.php
@@ -17,13 +17,13 @@ use LaminasTest\Ldap as TestLdap;
  */
 class UpdateTest extends TestLdap\AbstractOnlineTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareLDAPServer();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (! getenv('TESTS_LAMINAS_LDAP_ONLINE_ENABLED')) {
             return;

--- a/test/OfflineReconnectTest.php
+++ b/test/OfflineReconnectTest.php
@@ -20,7 +20,7 @@ class OfflineReconnectTest extends OfflineTest
         BuiltinFunctionMocks::$ldap_set_option_mock->enable();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         Mock::disableAll();

--- a/test/OfflineTest.php
+++ b/test/OfflineTest.php
@@ -177,12 +177,12 @@ class OfflineTest extends TestCase
 
     public function testRemovingAttributesFails()
     {
-        $this->expectException(LdapException::class);
         $ldap_mod_del = $this->getFunctionMock('Laminas\\Ldap', 'ldap_mod_del');
         $ldap_mod_del->expects($this->once())
                      ->willReturn(false);
 
         $ldap = new \Laminas\Ldap\Ldap();
+        $this->expectException(LdapException::class);
         $ldap->deleteAttributes('foo', ['bar']);
     }
 
@@ -211,12 +211,12 @@ class OfflineTest extends TestCase
 
     public function testAddingAttributesFails()
     {
-        $this->expectException(LdapException::class);
         $ldap_mod_del = $this->getFunctionMock('Laminas\\Ldap', 'ldap_mod_add');
         $ldap_mod_del->expects($this->once())
                      ->willReturn(false);
 
         $ldap = new \Laminas\Ldap\Ldap();
+        $this->expectException(LdapException::class);
         $ldap->addAttributes('foo', ['bar']);
     }
 
@@ -245,12 +245,12 @@ class OfflineTest extends TestCase
 
     public function testUpdatingAttributesFails()
     {
-        $this->expectException(LdapException::class);
         $ldap_mod_upd = $this->getFunctionMock('Laminas\\Ldap', 'ldap_mod_replace');
         $ldap_mod_upd->expects($this->once())
                      ->willReturn(false);
 
         $ldap = new \Laminas\Ldap\Ldap();
+        $this->expectException(LdapException::class);
         $ldap->updateAttributes('foo', ['bar']);
     }
 }

--- a/test/OfflineTest.php
+++ b/test/OfflineTest.php
@@ -10,8 +10,7 @@ namespace LaminasTest\Ldap;
 
 use Laminas\Config;
 use Laminas\Ldap;
-use Laminas\Ldap\Exception;
-use phpmock\Mock;
+use Laminas\Ldap\Exception\LdapException;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
 
@@ -37,7 +36,7 @@ class OfflineTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->ldap = new Ldap\Ldap();
     }
@@ -51,7 +50,7 @@ class OfflineTest extends TestCase
         try {
             $this->ldap->setOptions([$optionName => 'irrelevant']);
             $this->fail('Expected Laminas\Ldap\Exception\LdapException not thrown');
-        } catch (Exception\LdapException $e) {
+        } catch (LdapException $e) {
             $this->assertEquals("Unknown Laminas\Ldap\Ldap option: $optionName", $e->getMessage());
         }
     }
@@ -176,11 +175,9 @@ class OfflineTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Laminas\Ldap\Exception\LdapException
-     */
     public function testRemovingAttributesFails()
     {
+        $this->expectException(LdapException::class);
         $ldap_mod_del = $this->getFunctionMock('Laminas\\Ldap', 'ldap_mod_del');
         $ldap_mod_del->expects($this->once())
                      ->willReturn(false);
@@ -212,11 +209,9 @@ class OfflineTest extends TestCase
         $this->assertSame($ldap, $ldap->addAttributes($dn, $attributes, $allowEmptyAttributes));
     }
 
-    /**
-     * @expectedException \Laminas\Ldap\Exception\LdapException
-     */
     public function testAddingAttributesFails()
     {
+        $this->expectException(LdapException::class);
         $ldap_mod_del = $this->getFunctionMock('Laminas\\Ldap', 'ldap_mod_add');
         $ldap_mod_del->expects($this->once())
                      ->willReturn(false);
@@ -248,11 +243,9 @@ class OfflineTest extends TestCase
         $this->assertSame($ldap, $ldap->updateAttributes($dn, $attributes, $allowEmptyAttributes));
     }
 
-    /**
-     * @expectedException \Laminas\Ldap\Exception\LdapException
-     */
     public function testUpdatingAttributesFails()
     {
+        $this->expectException(LdapException::class);
         $ldap_mod_upd = $this->getFunctionMock('Laminas\\Ldap', 'ldap_mod_replace');
         $ldap_mod_upd->expects($this->once())
                      ->willReturn(false);

--- a/test/ReconnectTest.php
+++ b/test/ReconnectTest.php
@@ -47,7 +47,7 @@ class ReconnectTest extends AbstractOnlineTestCase
         return $options;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! getenv('TESTS_LAMINAS_LDAP_ONLINE_ENABLED')) {
             $this->markTestSkipped("Laminas_Ldap online tests are not enabled");
@@ -56,7 +56,7 @@ class ReconnectTest extends AbstractOnlineTestCase
         $this->getLDAP()->setOptions(static::getStandardOptions());
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         // Make sure we're using a non-expired connection with known settings
         // for each test.

--- a/test/SearchTest.php
+++ b/test/SearchTest.php
@@ -291,11 +291,7 @@ class SearchTest extends AbstractOnlineTestCase
             // do nothing - just iterate
         }
         $items->next();
-        // The "pass" expectation here is just that no exception was thrown.
-        // Getting to this point in the code is the "definition of pass".
-        // phpunit will flag this as a risky test if we do not assert anything,
-        // so assert something.
-        $this->assertIsObject($items);
+        $this->assertIsArray($items->current());
     }
 
     public function testUnknownCollectionClassThrowsException()

--- a/test/SearchTest.php
+++ b/test/SearchTest.php
@@ -50,8 +50,8 @@ class SearchTest extends AbstractOnlineTestCase
 
     public function testGetSingleIllegalEntryWithException()
     {
-        $this->expectException(LdapException::class);
         $dn    = $this->createDn('ou=Test99,');
+        $this->expectException(LdapException::class);
         $entry = $this->getLDAP()->getEntry($dn, [], true);
     }
 
@@ -128,8 +128,8 @@ class SearchTest extends AbstractOnlineTestCase
 
     public function testIllegalSearch()
     {
-        $this->expectException(LdapException::class);
         $dn    = $this->createDn('ou=Node2,');
+        $this->expectException(LdapException::class);
         $items = $this->getLDAP()->search('(objectClass=account)', $dn, Ldap\Ldap::SEARCH_SCOPE_SUB);
     }
 

--- a/test/SearchTest.php
+++ b/test/SearchTest.php
@@ -11,6 +11,7 @@ namespace LaminasTest\Ldap;
 use Laminas\Ldap;
 use Laminas\Ldap\Collection;
 use Laminas\Ldap\Exception;
+use Laminas\Ldap\Exception\LdapException;
 use LaminasTest\Ldap\TestAsset\CustomNaming;
 
 /**
@@ -18,13 +19,13 @@ use LaminasTest\Ldap\TestAsset\CustomNaming;
  */
 class SearchTest extends AbstractOnlineTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareLDAPServer();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->cleanupLDAPServer();
         parent::tearDown();
@@ -47,11 +48,9 @@ class SearchTest extends AbstractOnlineTestCase
         $this->assertNull($entry);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\LdapException
-     */
     public function testGetSingleIllegalEntryWithException()
     {
+        $this->expectException(LdapException::class);
         $dn    = $this->createDn('ou=Test99,');
         $entry = $this->getLDAP()->getEntry($dn, [], true);
     }
@@ -123,15 +122,13 @@ class SearchTest extends AbstractOnlineTestCase
             getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'),
             Ldap\Ldap::SEARCH_SCOPE_SUB
         );
-        $this->assertInternalType("array", $entries);
+        $this->assertIsArray($entries);
         $this->assertCount(9, $entries);
     }
 
-    /**
-     * @expectedException Laminas\Ldap\Exception\LdapException
-     */
     public function testIllegalSearch()
     {
+        $this->expectException(LdapException::class);
         $dn    = $this->createDn('ou=Node2,');
         $items = $this->getLDAP()->search('(objectClass=account)', $dn, Ldap\Ldap::SEARCH_SCOPE_SUB);
     }
@@ -229,7 +226,7 @@ class SearchTest extends AbstractOnlineTestCase
         $filter = Ldap\Filter::equals('objectClass', 'organizationalUnit');
 
         $entries = $this->getLDAP()->searchEntries($filter, $dn, Ldap\Ldap::SEARCH_SCOPE_SUB);
-        $this->assertInternalType("array", $entries);
+        $this->assertIsArray($entries);
         $this->assertCount(9, $entries);
     }
 
@@ -294,6 +291,11 @@ class SearchTest extends AbstractOnlineTestCase
             // do nothing - just iterate
         }
         $items->next();
+        // The "pass" expectation here is just that no exception was thrown.
+        // Getting to this point in the code is the "definition of pass".
+        // phpunit will flag this as a risky test if we do not assert anything,
+        // so assert something.
+        $this->assertIsObject($items);
     }
 
     public function testUnknownCollectionClassThrowsException()
@@ -308,8 +310,8 @@ class SearchTest extends AbstractOnlineTestCase
                 'This_Class_Does_Not_Exist'
             );
             $this->fail('Expected exception not thrown');
-        } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+        } catch (LdapException $zle) {
+            $this->assertStringContainsString(
                 "Class 'This_Class_Does_Not_Exist' can not be found",
                 $zle->getMessage()
             );
@@ -328,8 +330,8 @@ class SearchTest extends AbstractOnlineTestCase
                 'LaminasTest\Ldap\TestAsset\CollectionClassNotSubclassingLaminasLDAPCollection'
             );
             $this->fail('Expected exception not thrown');
-        } catch (Exception\LdapException $zle) {
-            $this->assertContains(
+        } catch (LdapException $zle) {
+            $this->assertStringContainsString(
                 "Class 'LaminasTest\\Ldap\\TestAsset\\CollectionClassNotSubclassingLaminasLDAPCollection'"
                 . " must subclass 'Laminas\\Ldap\\Collection'",
                 $zle->getMessage()
@@ -488,7 +490,7 @@ class SearchTest extends AbstractOnlineTestCase
         );
         $this->assertEquals(getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'), $items->getInnerIterator()->key());
         $current = $items->getInnerIterator()->current();
-        $this->assertInternalType('array', $current);
+        $this->assertIsArray($current);
         $this->assertEquals(getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'), $current['dn']);
     }
 
@@ -505,7 +507,7 @@ class SearchTest extends AbstractOnlineTestCase
         $this->assertEquals(0, $items->key());
         $this->assertEquals(getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'), $items->dn());
         $current = $items->current();
-        $this->assertInternalType('array', $current);
+        $this->assertIsArray($current);
         $this->assertEquals(getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'), $current['dn']);
     }
 
@@ -551,7 +553,7 @@ class SearchTest extends AbstractOnlineTestCase
         $this->assertEquals(9, $items->count());
         $this->assertEquals(getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'), $items->getInnerIterator()->key());
         $current = $items->current();
-        $this->assertInternalType('array', $current);
+        $this->assertIsArray($current);
         $this->assertEquals(getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'), $current['dn']);
 
         $i = 0;

--- a/test/SortTest.php
+++ b/test/SortTest.php
@@ -12,13 +12,13 @@ use Laminas\Ldap\Collection\DefaultIterator;
 
 class SortTest extends AbstractOnlineTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->prepareLDAPServer();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->cleanupLDAPServer();
         parent::tearDown();
@@ -41,9 +41,12 @@ class SortTest extends AbstractOnlineTestCase
             return 1;
         };
 
-        $this->assertAttributeEquals('strnatcasecmp', 'sortFunction', $iterator);
+        $reflectionObject = new \ReflectionObject($iterator);
+        $reflectionProperty = $reflectionObject->getProperty('sortFunction');
+        $reflectionProperty->setAccessible(true);
+        $this->assertEquals('strnatcasecmp', $reflectionProperty->getValue($iterator));
         $iterator->setSortFunction($sortFunction);
-        $this->assertAttributeEquals($sortFunction, 'sortFunction', $iterator);
+        $this->assertEquals($sortFunction, $reflectionProperty->getValue($iterator));
     }
 
     /**
@@ -62,32 +65,20 @@ class SortTest extends AbstractOnlineTestCase
 
         $iterator = new DefaultIterator($this->getLdap(), $search);
 
-        $this->assertAttributeEquals('strnatcasecmp', 'sortFunction', $iterator);
         $reflectionObject = new \ReflectionObject($iterator);
+        $reflectionProperty = $reflectionObject->getProperty('sortFunction');
+        $reflectionProperty->setAccessible(true);
+        $this->assertEquals('strnatcasecmp', $reflectionProperty->getValue($iterator));
+
         $reflectionProperty = $reflectionObject->getProperty('entries');
         $reflectionProperty->setAccessible(true);
-        $reflectionEntries = $reflectionProperty->getValue($iterator);
 
         $iterator->sort('l');
 
-        $this->assertAttributeEquals([
-            [
-                'resource' => $reflectionEntries[4]['resource'],
-                'sortValue' => 'a',
-            ], [
-                'resource' => $reflectionEntries[3]['resource'],
-                'sortValue' => 'b',
-            ], [
-                'resource' => $reflectionEntries[2]['resource'],
-                'sortValue' => 'c',
-            ], [
-                'resource' => $reflectionEntries[1]['resource'],
-                'sortValue' => 'd',
-            ], [
-                'resource' => $reflectionEntries[0]['resource'],
-                'sortValue' => 'e',
-            ],
-        ], 'entries', $iterator);
+        $reflectionEntries = $reflectionProperty->getValue($iterator);
+        foreach ($lSorted as $index => $value) {
+            $this->assertEquals($value, $reflectionEntries[$index]["sortValue"]);
+        }
     }
 
     /**
@@ -95,7 +86,7 @@ class SortTest extends AbstractOnlineTestCase
      */
     public function testCustomSorting()
     {
-        $lSorted = ['a', 'b', 'c', 'd', 'e'];
+        $lSorted = ['d', 'e', 'a', 'b', 'c'];
 
         $search = ldap_search(
             $this->getLDAP()->getResource(),
@@ -119,31 +110,19 @@ class SortTest extends AbstractOnlineTestCase
         };
         $iterator->setSortFunction($sortFunction);
 
-        $this->assertAttributeEquals($sortFunction, 'sortFunction', $iterator);
         $reflectionObject = new \ReflectionObject($iterator);
+        $reflectionProperty = $reflectionObject->getProperty('sortFunction');
+        $reflectionProperty->setAccessible(true);
+        $this->assertEquals($sortFunction, $reflectionProperty->getValue($iterator));
+
         $reflectionProperty = $reflectionObject->getProperty('entries');
         $reflectionProperty->setAccessible(true);
-        $reflectionEntries = $reflectionProperty->getValue($iterator);
 
         $iterator->sort('l');
 
-        $this->assertAttributeEquals([
-            [
-                'resource' => $reflectionEntries[1]['resource'],
-                'sortValue' => 'd',
-            ], [
-                'resource' => $reflectionEntries[0]['resource'],
-                'sortValue' => 'e',
-            ], [
-                'resource' => $reflectionEntries[4]['resource'],
-                'sortValue' => 'a',
-            ], [
-                'resource' => $reflectionEntries[3]['resource'],
-                'sortValue' => 'b',
-            ], [
-                'resource' => $reflectionEntries[2]['resource'],
-                'sortValue' => 'c',
-            ],
-        ], 'entries', $iterator);
+        $reflectionEntries = $reflectionProperty->getValue($iterator);
+        foreach ($lSorted as $index => $value) {
+            $this->assertEquals($value, $reflectionEntries[$index]["sortValue"]);
+        }
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no (dropping support for old PHP versions is not considered a BC break - see comment below)
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Issue #11 

