### PR TITLE
Typo fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /laminas-mkdoc-theme.tgz
 /laminas-mkdoc-theme/
 /phpunit.xml
+/.phpunit.result.cache
 /vendor/

--- a/docs/book/api.md
+++ b/docs/book/api.md
@@ -23,7 +23,7 @@ allowEmptyPassword     | Some LDAP servers can be configured to accept an empty 
 optReferrals           | If set to `true`, this option indicates to the LDAP client that referrals should be followed. The default value is `false`.
 tryUsernameSplit       | If set to `false`, this option indicates that the given username should not be split at the first `@` or `\\` character to separate the username from the domain during the binding-procedure. This allows the user to use usernames that contain an `@` or `\\` character that do not inherit some domain-information, e.g. using email-addresses for binding. The default value is `true`.
 networkTimeout         | Number of seconds to wait for LDAP connection before fail. If not set, the default value is the system value.
-reconnectAttempts      | Number of times the client tries to reconnect to the server after the connection was lost before finally giving up. This might be especially helpfull in long running applications. The defalt value is `0` (Connect once and do not try to reconnect - behaviour up to version 2.9.0)
+reconnectAttempts      | Number of times the client tries to reconnect to the server after the connection was lost before finally giving up. This might be especially helpful in long running applications. The default value is `0` (Connect once and do not try to reconnect - behaviour up to version 2.9.0)
 
 ## API Reference
 

--- a/src/Dn.php
+++ b/src/Dn.php
@@ -498,7 +498,7 @@ class Dn implements ArrayAccess
     /**
      * Undoes the conversion done by {@link escapeValue()}.
      *
-     * Any escape sequence starting with a baskslash - hexpair or special character -
+     * Any escape sequence starting with a backslash - hexpair or special character -
      * will be transformed back to the corresponding character.
      * @see    Net_LDAP2_Util::escape_dn_value() from Benedikt Hallinger <beni@php.net>
      * @link   http://pear.php.net/package/Net_LDAP2

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -16,7 +16,7 @@ namespace Laminas\Ldap;
 class ErrorHandler implements ErrorHandlerInterface
 {
     /**
-     * @var ErrorHandlerInterface The Errror-Handler instance
+     * @var ErrorHandlerInterface The Error-Handler instance
      */
     protected static $errorHandler;
 

--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -72,7 +72,7 @@ abstract class AbstractFilter
     /**
      * Escapes the given VALUES according to RFC 2254 so that they can be safely used in LDAP filters.
      *
-     * Any control characters with an ACII code < 32 as well as the characters with special meaning in
+     * Any control characters with an ASCII code < 32 as well as the characters with special meaning in
      * LDAP filters "*", "(", ")", and "\" (the backslash) are converted into the representation of a
      * backslash followed by two hex digits representing the hexadecimal value of the character.
      * @see    Net_LDAP2_Util::escape_filter_value() from Benedikt Hallinger <beni@php.net>

--- a/test/AttributeTest.php
+++ b/test/AttributeTest.php
@@ -308,7 +308,7 @@ class AttributeTest extends TestCase
         $this->assertEquals('dummy', $retTs);
     }
 
-    public function testGetDateTimeValueNegativeOffet()
+    public function testGetDateTimeValueNegativeOffset()
     {
         $data      = ['ts' => ['20080612143045-0700']];
         $retTs     = Attribute::getDateTimeAttribute($data, 'ts', 0);
@@ -316,7 +316,7 @@ class AttributeTest extends TestCase
         $this->assertEquals($tsCompare, $retTs);
     }
 
-    public function testGetDateTimeValueNegativeOffet2()
+    public function testGetDateTimeValueNegativeOffset2()
     {
         $data      = ['ts' => ['20080612143045-0715']];
         $retTs     = Attribute::getDateTimeAttribute($data, 'ts', 0);

--- a/test/CanonTest.php
+++ b/test/CanonTest.php
@@ -359,7 +359,7 @@ class CanonTest extends TestCase
         }
     }
 
-    public function testGetUnavailableCanoncialForm()
+    public function testGetUnavailableCanonicalForm()
     {
         $options = $this->options;
         unset($options['accountDomainName']);

--- a/test/CrudTest.php
+++ b/test/CrudTest.php
@@ -142,7 +142,7 @@ class CrudTest extends AbstractOnlineTestCase
         }
         $this->assertTrue(
             $exCaught,
-            'Execption not raised when deleting item with children without specifiying recursive delete'
+            'Exception not raised when deleting item with children without specifying recursive delete'
         );
         $this->getLDAP()->delete($topDn, true);
         $this->assertFalse($this->getLDAP()->exists($topDn));

--- a/test/ErrorHandlerTest.php
+++ b/test/ErrorHandlerTest.php
@@ -45,7 +45,7 @@ class ErrorHandlerTest extends TestCase
         restore_error_handler();
     }
 
-    public function testErrorHandlerREmovalWorks()
+    public function testErrorHandlerRemovalWorks()
     {
         $errorHandler = new ErrorHandler();
 

--- a/test/Node/OfflineTest.php
+++ b/test/Node/OfflineTest.php
@@ -240,7 +240,7 @@ class OfflineTest extends TestLdap\AbstractTestCase
     public function testExistsAttribute()
     {
         $node = $this->createTestNode();
-        $this->assertFalse($node->existsAttribute('nonExistant'));
+        $this->assertFalse($node->existsAttribute('nonExistent'));
         $this->assertFalse($node->existsAttribute('empty', false));
         $this->assertTrue($node->existsAttribute('empty', true));
 

--- a/test/OfflineReconnectTest.php
+++ b/test/OfflineReconnectTest.php
@@ -10,7 +10,7 @@ class OfflineReconnectTest extends OfflineTest
 {
     /**
      * Enables mocks for ldap_connect(), ldap_bind(), and ldap_set_option().
-     * Not all tests need or are compatible with this, so it is called expliclty
+     * Not all tests need or are compatible with this, so it is called explicitly
      * by tests that do.
      */
     protected function activateBindableOfflineMocks()


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | yes (just a typo fix)
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes (only fixing typos that do not effect run-time)

### Description

1) ignore `.phpunit.result.cache` - this is produced nowadays when running phpunit9. We don't want people to accidentally commit it.
2) fix various typos that my IDE noticed. There is nothing important that effects real behaviour.