### PR TITLE
Create separate testsuite for connectivity-tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd" bootstrap="test/bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="test/bootstrap.php"
+         colors="true"
+         defaultTestSuite="default"
+>
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">./src</directory>
     </include>
   </coverage>
   <testsuites>
-    <testsuite name="laminas-ldap Test Suite">
+    <testsuite name="default">
       <directory>./test</directory>
+      <exclude>./test/ConnectTest.php</exclude>>
+      <exclude>./test/OfflineReconnectTest.php</exclude>
+      <exclude>./test/ReconnectTest.php</exclude>
+    </testsuite>
+    <testsuite name="connectivity">
+      <file>./test/ConnectTest.php</file>
+      <file>./test/OfflineReconnectTest.php</file>
+      <file>./test/ReconnectTest.php</file>
     </testsuite>
   </testsuites>
   <php>


### PR DESCRIPTION
This separate testsuite would allow us to run the basic tests for now
while figuring out ways to run the connectivity tests on github-actions.

This is a first step to get back to a fully green testsuite. Next step would be to merge #27 

Then the next step would be to get the now separated connectivity tests back up via github actions. This will be a separate PR
