### PR TITLE
Remove obsoleted file, fixing `php$VERSION-ldap` package installation

### DIFF
--- a/.laminas-ci/pre-install.sh
+++ b/.laminas-ci/pre-install.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-WORKING_DIRECTORY=$2
-JOB=$3
-PHP_VERSION=$(echo "${JOB}" | jq -r '.php')
-
-apt install -y php8.1-ldap || exit 1


### PR DESCRIPTION
By now the PHP8.1 installation works out of the box so we can get rid of
the pre-install script as that duplicates the requirement of the LDAP
extension. It also required the PHP8.1 extension on all tests regardless
of the PHP-version