### PR TITLE
Dropped PHP 7.3, upgraded to `laminas/laminas-coding-standard:~2.3.0`, improved internal type documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 [![Coverage Status](https://coveralls.io/repos/github/laminas/laminas-ldap/badge.svg?branch=master)](https://coveralls.io/github/laminas/laminas-ldap?branch=master)
 
 > ## 🇷🇺 Русским гражданам
-> 
+>
 > Мы, участники Laminas, родились и живем в разных странах. У многих из нас есть друзья, родственники и коллеги как в России, так и в Украине. Некоторые из нас родились в России. Некоторые из нас живут в России. У некоторых бабушки и дедушки сражались с фашистами во Второй мировой войне. Здесь никто не поддерживает фашизм.
-> 
+>
 > У одного из нас есть украинская родственница, которая спаслась из дома вместе с сыном. Поезд задержался из-за бомбежки на дороге впереди. У нас есть друзья, которые прячутся в бомбоубежищах. Мы с тревогой ждем весточки от них после воздушных налетов, которые беспорядочно наносят удары и попадают по больницам, школам, детским садам и домам. Мы не берем это из каких-либо СМИ. Мы наблюдаем это напрямую.
-> 
+>
 > Вы доверяете нам достаточно, чтоб использовать наши программы, и мы просим вас довериться нам вновь. Мы нуждаемся в помощи. Выходите и протестуйте против этой бесполезной войны. Остановите кровопролитие. Скажите "Нет войне!"
-> 
+>
 > ## 🇺🇸 To Citizens of Russia
-> 
+>
 > We at Laminas come from all over the world. Many of us have friends, family and colleagues in both Russia and Ukraine. Some of us were born in Russia. Some of us currently live in Russia. Some have grandparents who fought Nazis in World War II. Nobody here supports fascism.
-> 
+>
 > One team member has a Ukrainian relative who fled her home with her son. The train was delayed due to bombing on the road ahead. We have friends who are hiding in bomb shelters. We anxiously follow up on them after the air raids, which indiscriminately fire at hospitals, schools, kindergartens and houses. We're not taking this from any media. These are our actual experiences.
-> 
+>
 > You trust us enough to use our software. We ask that you trust us to say the truth on this. We need your help. Go out and protest this unnecessary war. Stop the bloodshed. Say "stop the war!"
 
 laminas-ldap provides functionality for performing LDAP operations, including, but

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "platform": {
-            "php": "7.3.99"
+            "php": "7.4.99"
         },
         "sort-packages": true
     },
     "extra": {
     },
     "require": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-ldap": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-ldap": "*"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.3.0",
         "laminas/laminas-config": "^3.7.0",
         "laminas/laminas-eventmanager": "^3.4.0",
         "laminas/laminas-stdlib": "^3.7.1",

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,13 @@
         "forum": "https://discourse.laminas.dev"
     },
     "config": {
-        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
         "platform": {
             "php": "7.3.99"
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d898409acf8e2c391d4208bb052e498",
+    "content-hash": "25f5407da9398fd87e9a4b93e439d1f8",
     "packages": [],
     "packages-dev": [
         {
@@ -465,6 +465,81 @@
             "time": "2022-02-25T21:32:43+00:00"
         },
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "v0.1.1",
             "source": {
@@ -674,31 +749,36 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "php": "^7.3 || ^8.0",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.6",
+                "webimpress/coding-standard": "^1.2"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -712,7 +792,13 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-05-29T15:53:59+00:00"
         },
         {
             "name": "laminas/laminas-config",
@@ -906,68 +992,6 @@
                 }
             ],
             "time": "2022-07-27T12:28:58+00:00"
-        },
-        {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/88bf037259869891afce6504cacc4f8a07b24d0f",
-                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-12-21T14:34:37+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1715,6 +1739,51 @@
                 "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
             "time": "2021-12-08T12:19:24+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "135607f9ccc297d6923d49c2bcf309f509413215"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/135607f9ccc297d6923d49c2bcf309f509413215",
+                "reference": "135607f9ccc297d6923d49c2bcf309f509413215",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.4"
+            },
+            "time": "2022-06-26T13:09:08+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3259,64 +3328,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "7.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.5.1",
+                "squizlabs/php_codesniffer": "^3.6.2"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.3",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.7.1",
+                "phpstan/phpstan-deprecation-rules": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
+                "phpstan/phpstan-strict-rules": "1.2.3",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.20"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-25T10:58:12+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3329,7 +3432,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -3339,7 +3442,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "symfony/console",
@@ -4324,6 +4427,61 @@
                 "source": "https://github.com/vimeo/psalm/tree/4.24.0"
             },
             "time": "2022-06-26T11:47:54+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.13"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-15T19:52:12+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "25f5407da9398fd87e9a4b93e439d1f8",
+    "content-hash": "45cf540ca822dbd268dcf1d3f913d647",
     "packages": [],
     "packages-dev": [
         {
@@ -248,20 +248,20 @@
         },
         {
             "name": "composer/pcre",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "c8e9d27cfc5ed22643c19c160455b473ffd8aabe"
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/c8e9d27cfc5ed22643c19c160455b473ffd8aabe",
-                "reference": "c8e9d27cfc5ed22643c19c160455b473ffd8aabe",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.3",
@@ -271,7 +271,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -299,7 +299,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/2.0.0"
+                "source": "https://github.com/composer/pcre/tree/3.0.0"
             },
             "funding": [
                 {
@@ -315,7 +315,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-25T20:05:29+00:00"
+            "time": "2022-02-25T20:21:48+00:00"
         },
         {
             "name": "composer/semver",
@@ -870,35 +870,36 @@
         },
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.4.0",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba"
+                "reference": "41f7209428f37cab9573365e361f4078209aaafa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
-                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/41f7209428f37cab9573365e361f4078209aaafa",
+                "reference": "41f7209428f37cab9573365e361f4078209aaafa",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
+                "container-interop/container-interop": "<1.2",
                 "zendframework/zend-eventmanager": "*"
             },
             "require-dev": {
-                "container-interop/container-interop": "^1.1",
                 "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-stdlib": "^3.6",
                 "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.5"
+                "phpunit/phpunit": "^9.5.5",
+                "psr/container": "^1.1.2 || ^2.0.2"
             },
             "suggest": {
-                "container-interop/container-interop": "^1.1, to use the lazy listeners feature",
-                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
+                "psr/container": "^1.1.2 || ^2.0.2, to use the lazy listeners feature"
             },
             "type": "library",
             "autoload": {
@@ -932,7 +933,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-07T22:35:32+00:00"
+            "time": "2022-04-06T21:05:17+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -1742,16 +1743,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.6.4",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "135607f9ccc297d6923d49c2bcf309f509413215"
+                "reference": "981cc368a216c988e862a75e526b6076987d1b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/135607f9ccc297d6923d49c2bcf309f509413215",
-                "reference": "135607f9ccc297d6923d49c2bcf309f509413215",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/981cc368a216c988e862a75e526b6076987d1b50",
+                "reference": "981cc368a216c988e862a75e526b6076987d1b50",
                 "shasum": ""
             },
             "require": {
@@ -1761,7 +1762,6 @@
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.5",
-                "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
@@ -1781,9 +1781,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.4"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.5.1"
             },
-            "time": "2022-06-26T13:09:08+00:00"
+            "time": "2022-05-05T11:32:40+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2267,20 +2267,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -2309,9 +2309,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/log",
@@ -4323,16 +4323,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.24.0",
+            "version": "v4.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "06dd975cb55d36af80f242561738f16c5f58264f"
+                "reference": "d7cd84c4ebca74ba3419b9601f81d177bcbe2aac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/06dd975cb55d36af80f242561738f16c5f58264f",
-                "reference": "06dd975cb55d36af80f242561738f16c5f58264f",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d7cd84c4ebca74ba3419b9601f81d177bcbe2aac",
+                "reference": "d7cd84c4ebca74ba3419b9601f81d177bcbe2aac",
                 "shasum": ""
             },
             "require": {
@@ -4424,9 +4424,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.24.0"
+                "source": "https://github.com/vimeo/psalm/tree/v4.25.0"
             },
-            "time": "2022-06-26T11:47:54+00:00"
+            "time": "2022-07-25T17:04:37+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -4599,12 +4599,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-ldap": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3.99"
+        "php": "7.4.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,30 @@
 <?xml version="1.0"?>
 <ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+    <rule ref="LaminasCodingStandard"/>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing">
+        <!-- strict types are too risky to introduce in existing sources here, and have been disabled, for now -->
+        <exclude-pattern>src/</exclude-pattern>
+    </rule>
+    
+    <rule ref="WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCaps">
+        <!-- renaming all non-camel-case variables now is of very little value, and lots of review overhead -->
+        <exclude-pattern>src/</exclude-pattern>
+        <exclude-pattern>test/</exclude-pattern>
+    </rule>
+
+    <rule ref="WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCapsProperty">
+        <!-- renaming all non-camel-case variables now is of very little value, and lots of review overhead -->
+        <exclude-pattern>src/</exclude-pattern>
+        <exclude-pattern>test/</exclude-pattern>
+    </rule>
+    
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName">
+        <!-- our test suite relies on `ldap_*` functions being mocked out, therefore we can't really import them -->
+        <exclude-pattern>src</exclude-pattern>
+        <exclude-pattern>test</exclude-pattern>
+    </rule>
+
 
     <!-- Paths to check -->
     <file>src</file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.13.1@5cf660f63b548ccd4a56f62d916ee4d6028e01a3">
+<files psalm-version="v4.25.0@d7cd84c4ebca74ba3419b9601f81d177bcbe2aac">
   <file src="src/Attribute.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>is_int($value)</code>
+      <code>is_string($value)</code>
+    </DocblockTypeContradiction>
     <InvalidReturnStatement occurrences="2">
       <code>$value-&gt;format('U')</code>
       <code>Converter\Converter::fromLdapDateTime($value, false)-&gt;format('U')</code>
@@ -50,39 +54,24 @@
     <MixedReturnStatement occurrences="1">
       <code>$values</code>
     </MixedReturnStatement>
-    <RedundantConditionGivenDocblockType occurrences="5">
+    <RedundantConditionGivenDocblockType occurrences="3">
       <code>$value !== null</code>
       <code>$value !== null</code>
       <code>is_int($index)</code>
-      <code>is_int($value)</code>
-      <code>is_string($value)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Collection.php">
-    <InvalidNullableReturnType occurrences="1">
-      <code>array</code>
-    </InvalidNullableReturnType>
     <MixedInferredReturnType occurrences="1">
       <code>array|null</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="1">
       <code>$this-&gt;cache[$this-&gt;current]</code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;current()</code>
-    </NullableReturnStatement>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="src/Collection/DefaultIterator.php">
     <InvalidArgument occurrences="1">
       <code>$this</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="2">
-      <code>$a</code>
-      <code>$b</code>
-    </MissingClosureParamType>
     <MissingClosureReturnType occurrences="1">
       <code>function ($a, $b) use ($sortFunction) {</code>
     </MissingClosureReturnType>
@@ -114,13 +103,13 @@
     <PossiblyInvalidFunctionCall occurrences="1">
       <code>call_user_func($this-&gt;attributeNameTreatment, $name)</code>
     </PossiblyInvalidFunctionCall>
-    <PossiblyNullPropertyAssignmentValue occurrences="5">
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$current</code>
+    </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(int) $attributeNameTreatment</code>
     </RedundantCastGivenDocblockType>
@@ -142,17 +131,10 @@
       <code>$time['offsetminutes']</code>
       <code>$time['second']</code>
     </InvalidScalarArgument>
-    <MissingClosureParamType occurrences="1">
-      <code>$matches</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="3">
-      <code>$matches[1]</code>
+    <MixedArgument occurrences="2">
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$matches[1]</code>
-    </MixedArrayAccess>
     <MixedAssignment occurrences="1">
       <code>$v</code>
     </MixedAssignment>
@@ -167,15 +149,6 @@
     <InvalidArgument occurrences="1">
       <code>[$key, $value]</code>
     </InvalidArgument>
-    <InvalidClass occurrences="4">
-      <code>DN</code>
-      <code>DN</code>
-      <code>DN</code>
-      <code>DN</code>
-    </InvalidClass>
-    <InvalidReturnType occurrences="1">
-      <code>bool</code>
-    </InvalidReturnType>
     <MissingReturnType occurrences="2">
       <code>setCaseFold</code>
       <code>setDefaultCaseFold</code>
@@ -209,8 +182,8 @@
       <code>array</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="2">
-      <code>(count($values) == 1) ? $values[0] : $values</code>
-      <code>(count($values) == 1) ? $values[0] : $values</code>
+      <code>count($values) === 1 ? $values[0] : $values</code>
+      <code>count($values) === 1 ? $values[0] : $values</code>
     </MixedReturnStatement>
     <NullArgument occurrences="2">
       <code>null</code>
@@ -259,10 +232,6 @@
       <code>! self::$errorHandler</code>
     </DocblockTypeContradiction>
     <InvalidArgument occurrences="1"/>
-    <MissingClosureParamType occurrences="2">
-      <code>$errNo</code>
-      <code>$errString</code>
-    </MissingClosureParamType>
     <UnusedClosureParam occurrences="2">
       <code>$errNo</code>
       <code>$errString</code>
@@ -312,8 +281,8 @@
       <code>array</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="2">
-      <code>(count($values) == 1) ? $values[0] : $values</code>
-      <code>(count($values) == 1) ? $values[0] : $values</code>
+      <code>count($values) === 1 ? $values[0] : $values</code>
+      <code>count($values) === 1 ? $values[0] : $values</code>
     </MixedReturnStatement>
   </file>
   <file src="src/Filter/AbstractLogicalFilter.php">
@@ -341,13 +310,12 @@
       <code>bool</code>
     </MixedInferredReturnType>
     <UndefinedDocblockClass occurrences="1">
-      <code>resource|\LDAP\Connection|\LDAP\Result|\LDAP\ResultEntry</code>
+      <code>resource|Connection|Result|ResultEntry</code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/Ldap.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion occurrences="1">
       <code>$duration * 1000000</code>
-      <code>'Laminas\Ldap\Collection'</code>
     </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="5">
       <code>$accountDomainName === null</code>
@@ -361,24 +329,15 @@
       <code>$aname</code>
       <code>$aname</code>
     </InvalidArgument>
-    <InvalidNullableReturnType occurrences="2">
+    <InvalidNullableReturnType occurrences="3">
       <code>Node</code>
       <code>array</code>
+      <code>array</code>
     </InvalidNullableReturnType>
-    <MissingParamType occurrences="3">
-      <code>$a</code>
-      <code>$b</code>
-      <code>$resource</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="6">
-      <code>coalesce</code>
-      <code>getReconnectsAttempted</code>
+    <MissingReturnType occurrences="1">
       <code>reconnectSleep</code>
-      <code>resetReconnectsAttempted</code>
-      <code>shouldReconnect</code>
-      <code>unbind</code>
     </MissingReturnType>
-    <MixedArgument occurrences="23">
+    <MixedArgument occurrences="22">
       <code>$c</code>
       <code>$c</code>
       <code>$c</code>
@@ -391,7 +350,6 @@
       <code>$message</code>
       <code>$password</code>
       <code>$password</code>
-      <code>$resource</code>
       <code>$this-&gt;connectString</code>
       <code>$username</code>
       <code>$username</code>
@@ -491,8 +449,11 @@
       <code>$this-&gt;options['useStartTls']</code>
       <code>$this-&gt;options['username']</code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="1">
+    <NullableReturnStatement occurrences="4">
+      <code>$acct</code>
+      <code>$result-&gt;getFirst()</code>
       <code>$this-&gt;getNode($this-&gt;getBaseDn(), $this)</code>
+      <code>null</code>
     </NullableReturnStatement>
     <PossiblyInvalidArgument occurrences="3">
       <code>$filter</code>
@@ -517,19 +478,19 @@
       <code>$sasl_realm</code>
       <code>$username</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="5">
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
     <PossiblyUndefinedVariable occurrences="2">
       <code>$err</code>
       <code>$err</code>
     </PossiblyUndefinedVariable>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor occurrences="5">
       <code>$connectString</code>
+      <code>$options</code>
+      <code>$resource</code>
+      <code>$rootDse</code>
+      <code>$schema</code>
     </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType occurrences="6">
       <code>(bool) $alwaysEmulate</code>
@@ -604,6 +565,9 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
+    <NullableReturnStatement occurrences="1">
+      <code>null</code>
+    </NullableReturnStatement>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $string</code>
     </RedundantCastGivenDocblockType>
@@ -613,10 +577,9 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Node.php">
-    <DocblockTypeContradiction occurrences="5">
+    <DocblockTypeContradiction occurrences="4">
       <code>$data === null</code>
       <code>$this-&gt;ldap === null</code>
-      <code>$this-&gt;newDn === null</code>
       <code>is_array($this-&gt;children)</code>
       <code>is_array($this-&gt;children)</code>
     </DocblockTypeContradiction>
@@ -636,9 +599,6 @@
       <code>array</code>
     </InvalidReturnType>
     <LessSpecificReturnStatement occurrences="1"/>
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
     <MissingReturnType occurrences="6">
       <code>_setAttribute</code>
       <code>_setDateTimeAttribute</code>
@@ -647,13 +607,12 @@
       <code>markAsToBeDeleted</code>
       <code>triggerEvent</code>
     </MissingReturnType>
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="5">
       <code>$this-&gt;currentData[$key]</code>
       <code>$this-&gt;originalData[$key]</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
-      <code>static::$systemAttributes</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
       <code>$key</code>
@@ -672,7 +631,7 @@
       <code>$value</code>
     </MixedAssignment>
     <MoreSpecificReturnType occurrences="1">
-      <code>Node\Collection</code>
+      <code>Collection</code>
     </MoreSpecificReturnType>
     <NullableReturnStatement occurrences="1">
       <code>static::fromLdap($parentDn, $ldap)</code>
@@ -694,17 +653,20 @@
       <code>(bool) $delete</code>
       <code>(bool) $new</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="9">
+    <RedundantConditionGivenDocblockType occurrences="8">
       <code>$dn instanceof Dn</code>
       <code>$dn instanceof Dn</code>
       <code>$this-&gt;events</code>
       <code>$this-&gt;events</code>
       <code>$this-&gt;ldap !== null</code>
-      <code>$this-&gt;newDn</code>
       <code>$this-&gt;newDn !== null</code>
       <code>is_array($this-&gt;children)</code>
       <code>is_array($this-&gt;children)</code>
     </RedundantConditionGivenDocblockType>
+    <RedundantPropertyInitializationCheck occurrences="2">
+      <code>$this-&gt;newDn</code>
+      <code>parent::_getDn()</code>
+    </RedundantPropertyInitializationCheck>
     <UnsafeInstantiation occurrences="3">
       <code>new static($dn, $data, $fromDataSource, null)</code>
       <code>new static($dn, $data, true, $ldap)</code>
@@ -715,18 +677,11 @@
     </UnusedForeachValue>
   </file>
   <file src="src/Node/AbstractNode.php">
-    <MissingParamType occurrences="1">
-      <code>$name</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$systemAttributes</code>
-    </MissingPropertyType>
     <MissingReturnType occurrences="1">
       <code>loadData</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$this-&gt;currentData[$name]</code>
-      <code>static::$systemAttributes</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$name</code>
@@ -751,11 +706,8 @@
     <InvalidNullableReturnType occurrences="1">
       <code>ChildrenIterator</code>
     </InvalidNullableReturnType>
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
     <MixedInferredReturnType occurrences="2">
-      <code>\Laminas\Ldap\Node</code>
+      <code>Node</code>
       <code>array|null</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="2">
@@ -766,10 +718,13 @@
       <code>key($this-&gt;data)</code>
       <code>string</code>
     </MixedReturnTypeCoercion>
+    <NullableReturnStatement occurrences="1">
+      <code>null</code>
+    </NullableReturnStatement>
   </file>
   <file src="src/Node/Collection.php">
     <ImplementedReturnTypeMismatch occurrences="2">
-      <code>\Laminas\Ldap\Node</code>
+      <code>Node</code>
       <code>string</code>
     </ImplementedReturnTypeMismatch>
     <InvalidNullableReturnType occurrences="1">
@@ -885,12 +840,12 @@
     </PossiblyNullArgument>
   </file>
   <file src="src/Node/Schema/AttributeType/ActiveDirectory.php">
-    <InvalidReturnType occurrences="4">
-      <code>bool</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-    </InvalidReturnType>
+    <ImplementedReturnTypeMismatch occurrences="4">
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+    </ImplementedReturnTypeMismatch>
     <MixedArrayAccess occurrences="1">
       <code>$this-&gt;ldapdisplayname[0]</code>
     </MixedArrayAccess>
@@ -929,14 +884,14 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Node/Schema/ObjectClass/ActiveDirectory.php">
-    <InvalidReturnType occurrences="6">
-      <code>array</code>
-      <code>array</code>
-      <code>array</code>
-      <code>int</code>
-      <code>string</code>
-      <code>string</code>
-    </InvalidReturnType>
+    <ImplementedReturnTypeMismatch occurrences="6">
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+    </ImplementedReturnTypeMismatch>
     <MixedArrayAccess occurrences="1">
       <code>$this-&gt;ldapdisplayname[0]</code>
     </MixedArrayAccess>
@@ -983,10 +938,10 @@
       <code>$this-&gt;oid</code>
       <code>$this-&gt;sup</code>
     </MixedReturnStatement>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
-      <code>null</code>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$inheritedMay</code>
+      <code>$inheritedMust</code>
+    </PropertyNotSetInConstructor>
   </file>
   <file src="src/Node/Schema/OpenLdap.php">
     <MissingReturnType occurrences="2">
@@ -1040,38 +995,14 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <PossiblyNullPropertyAssignmentValue occurrences="5">
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/AbstractOnlineTestCase.php">
-    <MissingParamType occurrences="1">
-      <code>$dn</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="3">
+    <MissingReturnType occurrences="1">
       <code>cleanupLDAPServer</code>
-      <code>createDn</code>
-      <code>prepareLDAPServer</code>
     </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>$dn</code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
-      <code>$dn</code>
-      <code>$dn</code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayOffset occurrences="1"/>
-    <MixedAssignment occurrences="1">
-      <code>$entry</code>
-    </MixedAssignment>
-    <MixedOperand occurrences="2">
-      <code>$dn</code>
-      <code>$dn</code>
-    </MixedOperand>
+    <PossiblyFalseOperand occurrences="1">
+      <code>getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE')</code>
+    </PossiblyFalseOperand>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>self::$ldap !== null</code>
     </RedundantConditionGivenDocblockType>
@@ -1095,63 +1026,16 @@
       <code>3.1415</code>
       <code>true</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="4">
-      <code>$localTimestamp</code>
-      <code>$timestamp</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="44">
-      <code>assertLocalDateTimeString</code>
-      <code>assertUtcDateTimeString</code>
-      <code>testArrayAppendAttribute</code>
-      <code>testArrayOverwriteAttribute</code>
-      <code>testArraySetAttribute</code>
-      <code>testBooleanAttributeHandling</code>
-      <code>testGetAttributeArray</code>
-      <code>testGetAttributeValue</code>
-      <code>testGetAttributeWithWrongIndexType</code>
-      <code>testGetDateTimeValueFromArray</code>
-      <code>testGetDateTimeValueFromLocal</code>
-      <code>testGetDateTimeValueFromUtc</code>
-      <code>testGetDateTimeValueIllegal</code>
-      <code>testGetDateTimeValueNegativeOffet</code>
-      <code>testGetDateTimeValueNegativeOffet2</code>
-      <code>testGetNonExistentAttribute</code>
-      <code>testGetNonExistentAttributeValue</code>
-      <code>testHasValue</code>
-      <code>testInvalidValue</code>
-      <code>testPasswordGenerationMD5</code>
-      <code>testPasswordGenerationSHA</code>
-      <code>testPasswordGenerationSMD5</code>
-      <code>testPasswordGenerationSSHA</code>
-      <code>testPasswordGenerationUnicodePwd</code>
-      <code>testPasswordSettingCustomAttribute</code>
-      <code>testPasswordSettingMD5</code>
-      <code>testPasswordSettingSHA</code>
-      <code>testPasswordSettingUnicodePwd</code>
-      <code>testRemoveAttributeMultipleValueArray</code>
-      <code>testRemoveAttributeMultipleValueSimple</code>
-      <code>testRemoveAttributeValueArray</code>
-      <code>testRemoveAttributeValueBoolean</code>
-      <code>testRemoveAttributeValueInteger</code>
-      <code>testRemoveAttributeValueSimple</code>
-      <code>testRemoveDuplicates</code>
-      <code>testSetAttributeWithFilestream</code>
-      <code>testSetAttributeWithObject</code>
-      <code>testSetDateTimeValueIllegal</code>
-      <code>testSetDateTimeValueLocal</code>
-      <code>testSetDateTimeValueLocalArray</code>
-      <code>testSetDateTimeValueUtc</code>
-      <code>testSimpleAppendAttribute</code>
-      <code>testSimpleOverwriteAttribute</code>
-      <code>testSimpleSetAttribute</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="4">
+    <MixedArgument occurrences="9">
       <code>$data['ts']</code>
-      <code>$localTimestamp</code>
-      <code>$timestamp</code>
-      <code>$utcTimestamp</code>
+      <code>$data['ts'][0]</code>
+      <code>$data['ts'][0]</code>
+      <code>$data['ts'][0]</code>
+      <code>$data['ts'][0]</code>
+      <code>$data['ts'][0]</code>
+      <code>$data['ts'][0]</code>
+      <code>$data['ts'][1]</code>
+      <code>$data['ts'][1]</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="12">
       <code>$data['file'][0]</code>
@@ -1167,46 +1051,34 @@
       <code>$data['ts'][1]</code>
       <code>$data['ts'][1]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$password</code>
       <code>$password</code>
       <code>$password</code>
       <code>$password</code>
-      <code>$utcTimestamp</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>$localTimestamp</code>
-    </MixedOperand>
-    <PossiblyFalseArgument occurrences="5">
-      <code>$tsValue</code>
+    <PossiblyFalseArgument occurrences="4">
       <code>strpos($md5, '}')</code>
       <code>strpos($sha, '}')</code>
       <code>strpos($smd5, '}')</code>
       <code>strpos($ssha, '}')</code>
     </PossiblyFalseArgument>
-    <PossiblyFalseOperand occurrences="1">
-      <code>date('YmdHis', $utcTimestamp)</code>
-    </PossiblyFalseOperand>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$utcTimestamp</code>
+    </PossiblyInvalidArgument>
     <PossiblyInvalidArrayAccess occurrences="2">
       <code>$retTs[0]</code>
       <code>$retTs[1]</code>
     </PossiblyInvalidArrayAccess>
   </file>
   <file src="test/BindTest.php">
-    <MissingParamType occurrences="1">
-      <code>$options</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="4">
-      <code>$altPrincipalName</code>
-      <code>$altUsername</code>
-      <code>$bindRequiresDn</code>
-      <code>$options</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="18">
-      <code>getSslLdap</code>
+    <InvalidArrayOffset occurrences="1">
+      <code>$options['accountDomainName']</code>
+    </InvalidArrayOffset>
+    <MissingReturnType occurrences="17">
       <code>testAnonymousBind</code>
       <code>testBindWithEmptyPassword</code>
       <code>testBindWithNullPassword</code>
@@ -1225,80 +1097,19 @@
       <code>testSaslBind</code>
       <code>testSaslBindNoExplicitUsername</code>
     </MissingReturnType>
-    <MixedArgument occurrences="23">
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$password</code>
-      <code>$this-&gt;altPrincipalName</code>
-      <code>$this-&gt;altUsername</code>
-      <code>$this-&gt;altUsername</code>
-      <code>$this-&gt;altUsername</code>
-      <code>$this-&gt;altUsername</code>
+    <PossiblyFalsePropertyAssignmentValue occurrences="2">
+      <code>getenv('TESTS_LAMINAS_LDAP_ALT_PRINCIPAL_NAME')</code>
+      <code>getenv('TESTS_LAMINAS_LDAP_ALT_USERNAME')</code>
+    </PossiblyFalsePropertyAssignmentValue>
+    <PropertyTypeCoercion occurrences="8">
       <code>$this-&gt;options</code>
       <code>$this-&gt;options</code>
       <code>$this-&gt;options</code>
       <code>$this-&gt;options</code>
       <code>$this-&gt;options</code>
       <code>$this-&gt;options</code>
-      <code>$username</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="10">
-      <code>$options['accountDomainName']</code>
-      <code>$options['baseDn']</code>
-      <code>$options['password']</code>
-      <code>$options['password']</code>
-      <code>$options['password']</code>
-      <code>$options['password']</code>
-      <code>$options['username']</code>
-      <code>$options['username']</code>
-      <code>$options['username']</code>
-      <code>$options['username']</code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="13">
-      <code>$options['accountCanonicalForm']</code>
-      <code>$options['allowEmptyPassword']</code>
-      <code>$options['allowEmptyPassword']</code>
-      <code>$options['bindRequiresDn']</code>
-      <code>$options['bindRequiresDn']</code>
-      <code>$options['bindRequiresDn']</code>
-      <code>$options['bindRequiresDn']</code>
-      <code>$options['bindRequiresDn']</code>
-      <code>$options['port']</code>
-      <code>$options['saslOpts']</code>
-      <code>$options['saslOpts']</code>
-      <code>$options['useSsl']</code>
-      <code>$options['username']</code>
-    </MixedArrayAssignment>
-    <MixedAssignment occurrences="14">
-      <code>$ldap</code>
-      <code>$ldap</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$options</code>
-      <code>$password</code>
-      <code>$username</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="4">
-      <code>bind</code>
-      <code>bind</code>
-      <code>getBoundUser</code>
-      <code>getLastErrorCode</code>
-    </MixedMethodCall>
+      <code>$this-&gt;options</code>
+    </PropertyTypeCoercion>
   </file>
   <file src="test/CanonTest.php">
     <MissingReturnType occurrences="12">
@@ -1395,11 +1206,8 @@
     </UnusedVariable>
   </file>
   <file src="test/ChangePasswordTest.php">
-    <ArgumentTypeCoercion occurrences="4">
+    <ArgumentTypeCoercion occurrences="1">
       <code>'Laminas\Ldap'</code>
-      <code>'Laminas\Ldap\Ldap'</code>
-      <code>'Laminas\Ldap\Ldap'</code>
-      <code>'\Laminas\Ldap\Ldap'</code>
     </ArgumentTypeCoercion>
     <InvalidScalarArgument occurrences="2">
       <code>512</code>
@@ -1411,40 +1219,6 @@
       <code>testChangePasswordWithUserAccountActiveDirectory</code>
       <code>testChangePasswordWithUserAccountOpenLDAP</code>
     </MissingReturnType>
-    <MixedArgument occurrences="26">
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="4">
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-    </MixedAssignment>
     <UndefinedClass occurrences="1">
       <code>'Laminas\Ldap'</code>
     </UndefinedClass>
@@ -1455,53 +1229,6 @@
       <code>$port</code>
       <code>$useSsl</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="3">
-      <code>$connectURI</code>
-      <code>$host</code>
-      <code>$ssl</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$options</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="15">
-      <code>connectionWithoutPortInOptionsArrayProvider</code>
-      <code>testBadPortConnect</code>
-      <code>testConnectWithUri</code>
-      <code>testConnectionWithoutPortInOptionsArray</code>
-      <code>testDisconnect</code>
-      <code>testEmptyOptionsConnect</code>
-      <code>testExplicitNetworkTimeoutConnect</code>
-      <code>testExplicitParamsConnect</code>
-      <code>testExplicitPortConnect</code>
-      <code>testGetErrorCode</code>
-      <code>testMultiConnect</code>
-      <code>testNetworkTimeoutConnect</code>
-      <code>testPlainConnect</code>
-      <code>testSetOptionsConnect</code>
-      <code>testUnknownHostConnect</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="11">
-      <code>$connectURI</code>
-      <code>$options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$this-&gt;options['networkTimeout']</code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
-      <code>$options['port']</code>
-    </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
-      <code>$options</code>
-    </MixedAssignment>
     <PossiblyFalseArgument occurrences="1">
       <code>$host</code>
     </PossiblyFalseArgument>
@@ -1509,63 +1236,27 @@
       <code>$host</code>
       <code>$host</code>
     </PossiblyFalseOperand>
+    <PropertyTypeCoercion occurrences="3">
+      <code>$this-&gt;options</code>
+      <code>$this-&gt;options</code>
+    </PropertyTypeCoercion>
   </file>
   <file src="test/Converter/ConverterTest.php">
-    <MissingParamType occurrences="15">
-      <code>$convert</code>
-      <code>$convert</code>
-      <code>$convert</code>
-      <code>$convert</code>
-      <code>$convert</code>
-      <code>$dateTimeAsUtc</code>
-      <code>$expect</code>
-      <code>$expect</code>
-      <code>$expect</code>
-      <code>$expect</code>
-      <code>$expect</code>
-      <code>$expect</code>
-      <code>$type</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="19">
-      <code>fromLdapDateTimeException</code>
-      <code>fromLdapDateTimeProvider</code>
-      <code>fromLdapProvider</code>
-      <code>fromLdapUnserializeProvider</code>
-      <code>testAsc2hex32</code>
-      <code>testFromLdap</code>
-      <code>testFromLdapBoolean</code>
-      <code>testFromLdapDateTimeThrowsException</code>
-      <code>testFromLdapUnserialize</code>
-      <code>testFromLdapUnserializeThrowsException</code>
-      <code>testHex2asc</code>
-      <code>testToLdap</code>
-      <code>testToLdapBoolean</code>
-      <code>testToLdapDateTime</code>
-      <code>testToLdapSerialize</code>
-      <code>toLdapBooleanProvider</code>
-      <code>toLdapDateTimeProvider</code>
-      <code>toLdapProvider</code>
-      <code>toLdapSerializeProvider</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="9">
-      <code>$convert</code>
-      <code>$convert</code>
+    <InvalidScalarArgument occurrences="1">
       <code>$convert['date']</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
+      <code>testFromLdapDateTimeThrowsException</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="4">
+      <code>$convert</code>
       <code>$convert['type']</code>
-      <code>$convert['utc']</code>
-      <code>$dateTimeAsUtc</code>
-      <code>$type</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="4">
-      <code>$convert['date']</code>
-      <code>$convert['type']</code>
-      <code>$convert['utc']</code>
-      <code>$convert['value']</code>
-    </MixedArrayAccess>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>testToLdap</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="test/CopyRenameTest.php">
     <MissingReturnType occurrences="25">
@@ -1595,33 +1286,6 @@
       <code>testSimpleLeafRenameEmulationWithDnObjects</code>
       <code>testSimpleLeafRenameWithDnObjects</code>
     </MissingReturnType>
-    <MixedArgument occurrences="6">
-      <code>$this-&gt;createDn('ou=DoesNotExist,')</code>
-      <code>$this-&gt;createDn('ou=DoesNotExist,')</code>
-      <code>$this-&gt;createDn('ou=Test1,')</code>
-      <code>$this-&gt;createDn('ou=Test1,')</code>
-      <code>$this-&gt;createDn('ou=Test1,ou=ParentDoesNotExist,')</code>
-      <code>$this-&gt;createDn('ou=Test1,ou=ParentDoesNotExist,')</code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$dn</code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayOffset occurrences="1"/>
-    <MixedAssignment occurrences="5">
-      <code>$this-&gt;newDn</code>
-      <code>$this-&gt;newSubTreeDn</code>
-      <code>$this-&gt;orgDn</code>
-      <code>$this-&gt;orgSubTreeDn</code>
-      <code>$this-&gt;targetSubTreeDn</code>
-    </MixedAssignment>
-    <MixedOperand occurrences="6">
-      <code>$this-&gt;orgSubTreeDn</code>
-      <code>$this-&gt;orgSubTreeDn</code>
-      <code>$this-&gt;orgSubTreeDn</code>
-      <code>$this-&gt;orgSubTreeDn</code>
-      <code>$this-&gt;orgSubTreeDn</code>
-      <code>$this-&gt;orgSubTreeDn</code>
-    </MixedOperand>
     <UnusedFunctionCall occurrences="1">
       <code>ldap_add</code>
     </UnusedFunctionCall>
@@ -1650,87 +1314,12 @@
       <code>testUpdatingEntryWithRdnAttributeValueMissingInData</code>
       <code>testZeroValueMakesItThroughSanitationProcess</code>
     </MissingReturnType>
-    <MixedArgument occurrences="80">
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
+    <MixedArgument occurrences="5">
       <code>$entry['objectclass']</code>
       <code>$entry['objectclass']</code>
       <code>$entry['objectclass']</code>
       <code>$entry['objectclass']</code>
       <code>$entry['ou']</code>
-      <code>$this-&gt;createDn('ou=TestCreated,')</code>
-      <code>$this-&gt;createDn('ou=TestCreated,')</code>
-      <code>$this-&gt;createDn('ou=TestCreated,')</code>
-      <code>$topDn</code>
-      <code>$topDn</code>
-      <code>$topDn</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="7">
       <code>$entry['associateddomain'][0]</code>
@@ -1746,26 +1335,6 @@
       <code>$entry['objectclass'][]</code>
       <code>$entry['objectclass'][]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="15">
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$topDn</code>
-    </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>$dn</code>
-    </MixedOperand>
     <UnusedVariable occurrences="1">
       <code>$entry</code>
     </UnusedVariable>
@@ -1792,30 +1361,6 @@
     </MissingReturnType>
   </file>
   <file src="test/Dn/ExplodingTest.php">
-    <MissingParamType occurrences="4">
-      <code>$expected</code>
-      <code>$expected</code>
-      <code>$input</code>
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="12">
-      <code>explodeDnOperationProvider</code>
-      <code>rfc2253DnProvider</code>
-      <code>testCoreExplodeDnWithMultiValuedRdn</code>
-      <code>testCreateDnArrayIllegalDn</code>
-      <code>testExplodeDn</code>
-      <code>testExplodeDnCaseFold</code>
-      <code>testExplodeDnOperation</code>
-      <code>testExplodeDnWithMultiValuedRdn</code>
-      <code>testExplodeDnWithMultiValuedRdn2</code>
-      <code>testExplodeDnWithSpaces</code>
-      <code>testExplodeDnWithUtf8Characters</code>
-      <code>testExplodeDnsProvidedByRFC2253</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$input</code>
-      <code>$input</code>
-    </MixedArgument>
     <UnusedVariable occurrences="1">
       <code>$dnArray</code>
     </UnusedVariable>
@@ -1866,27 +1411,19 @@
     <MissingClosureReturnType occurrences="1">
       <code>function ($errno, $error) {</code>
     </MissingClosureReturnType>
-    <MissingPropertyType occurrences="1">
-      <code>$dummyErrorHandler</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="2">
-      <code>testErrorHandlerRemovalWorks</code>
-      <code>testErrorHandlerSettingWorks</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="4">
+    <MixedArgumentTypeCoercion occurrences="4">
       <code>$this-&gt;dummyErrorHandler</code>
       <code>$this-&gt;dummyErrorHandler</code>
       <code>$this-&gt;dummyErrorHandler</code>
       <code>$this-&gt;dummyErrorHandler</code>
-    </MixedArgument>
+    </MixedArgumentTypeCoercion>
     <UnusedClosureParam occurrences="2">
       <code>$errno</code>
       <code>$error</code>
     </UnusedClosureParam>
   </file>
   <file src="test/Exception/LdapExceptionTest.php">
-    <MissingReturnType occurrences="2">
-      <code>constructorArgumentsProvider</code>
+    <MissingReturnType occurrences="1">
       <code>testException</code>
     </MissingReturnType>
   </file>
@@ -1956,27 +1493,6 @@
       <code>$actual[1]['userpassword']</code>
     </MixedArrayAccess>
   </file>
-  <file src="test/Ldif/SimpleEncoderTest.php">
-    <MissingParamType occurrences="4">
-      <code>$array</code>
-      <code>$expected</code>
-      <code>$expected</code>
-      <code>$string</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="11">
-      <code>attributeEncodingProvider</code>
-      <code>stringEncodingProvider</code>
-      <code>testAttributeEncoding</code>
-      <code>testChangedWrapCount</code>
-      <code>testEncodeMultipleAttributes</code>
-      <code>testEncodeUnsupportedType</code>
-      <code>testEncodingWithJapaneseCharacters</code>
-      <code>testNodeEncoding</code>
-      <code>testSorting</code>
-      <code>testStringEncoding</code>
-      <code>testSupressVersionHeader</code>
-    </MissingReturnType>
-  </file>
   <file src="test/Node/AttributeIterationTest.php">
     <MissingReturnType occurrences="1">
       <code>testSimpleIteration</code>
@@ -1998,8 +1514,7 @@
     <MixedArgument occurrences="1">
       <code>$n-&gt;getRdnArray()</code>
     </MixedArgument>
-    <MixedAssignment occurrences="4">
-      <code>$base</code>
+    <MixedAssignment occurrences="3">
       <code>$dn</code>
       <code>$n</code>
       <code>$rdn</code>
@@ -2009,9 +1524,6 @@
       <code>getRdnArray</code>
       <code>toString</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
-      <code>$base</code>
-    </MixedOperand>
     <PossiblyFalseArgument occurrences="2">
       <code>getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE')</code>
       <code>getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE')</code>
@@ -2026,13 +1538,6 @@
     </UnusedVariable>
   </file>
   <file src="test/Node/ChildrenTest.php">
-    <ArgumentTypeCoercion occurrences="5">
-      <code>'Laminas\Ldap\Node'</code>
-      <code>'Laminas\Ldap\Node'</code>
-      <code>'Laminas\Ldap\Node\ChildrenIterator'</code>
-      <code>'Laminas\Ldap\Node\ChildrenIterator'</code>
-      <code>'Laminas\Ldap\Node\ChildrenIterator'</code>
-    </ArgumentTypeCoercion>
     <InvalidMethodCall occurrences="1">
       <code>getChildren</code>
     </InvalidMethodCall>
@@ -2045,20 +1550,9 @@
       <code>testHasChildrenOnDetachedNodeWithPriorGetChildren</code>
       <code>testHasChildrenOnDetachedNodeWithoutPriorGetChildren</code>
     </MissingReturnType>
-    <MixedArgument occurrences="13">
+    <MixedArgument occurrences="2">
       <code>$children2</code>
       <code>$children2</code>
-      <code>$this-&gt;createDn('ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Test1,')</code>
-      <code>$this-&gt;createDn('ou=Test1,')</code>
-      <code>$this-&gt;createDn('ou=Test1,')</code>
-      <code>$this-&gt;createDn('ou=Test1,ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Test1,ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Test1,ou=Node,')</code>
     </MixedArgument>
     <MixedAssignment occurrences="8">
       <code>$children2</code>
@@ -2108,20 +1602,7 @@
     </PossiblyNullReference>
   </file>
   <file src="test/Node/OfflineTest.php">
-    <ArgumentTypeCoercion occurrences="3">
-      <code>'Laminas\Ldap\Node'</code>
-      <code>'Laminas\Ldap\Node'</code>
-      <code>'Laminas\Ldap\Node'</code>
-    </ArgumentTypeCoercion>
-    <MissingParamType occurrences="4">
-      <code>$localTimestamp</code>
-      <code>$timestamp</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="47">
-      <code>assertLocalDateTimeString</code>
-      <code>assertUtcDateTimeString</code>
+    <MissingReturnType occurrences="45">
       <code>testAppendToAttributeFirstTime</code>
       <code>testArrayAccess</code>
       <code>testAttributeAccessDnGet</code>
@@ -2168,18 +1649,15 @@
       <code>testToJson</code>
       <code>testToString</code>
     </MissingReturnType>
-    <MixedArgument occurrences="11">
+    <MixedArgument occurrences="8">
       <code>$data['dn']</code>
       <code>$data['dn']</code>
       <code>$data['dn']</code>
-      <code>$localTimestamp</code>
       <code>$node-&gt;getAttribute('key')</code>
       <code>$node-&gt;getAttribute('key')</code>
       <code>$node-&gt;getAttribute('userPassword')</code>
       <code>$node-&gt;key</code>
       <code>$node['key']</code>
-      <code>$timestamp</code>
-      <code>$utcTimestamp</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="4">
       <code>$node-&gt;cn[0]</code>
@@ -2187,21 +1665,14 @@
       <code>$node-&gt;key[0]</code>
       <code>$node['key'][0]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$cn</code>
       <code>$cn</code>
       <code>$newObject</code>
-      <code>$utcTimestamp</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>$localTimestamp</code>
-    </MixedOperand>
-    <PossiblyFalseArgument occurrences="1">
-      <code>$tsValue</code>
-    </PossiblyFalseArgument>
-    <PossiblyFalseOperand occurrences="1">
-      <code>date('YmdHis', $utcTimestamp)</code>
-    </PossiblyFalseOperand>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$utcTimestamp</code>
+    </PossiblyInvalidArgument>
     <UnusedVariable occurrences="3">
       <code>$node</code>
       <code>$node</code>
@@ -2209,12 +1680,6 @@
     </UnusedVariable>
   </file>
   <file src="test/Node/OnlineTest.php">
-    <ArgumentTypeCoercion occurrences="4">
-      <code>'Laminas\Ldap\Node'</code>
-      <code>'Laminas\Ldap\Node'</code>
-      <code>'Laminas\Ldap\Node'</code>
-      <code>'Laminas\Ldap\Node\Collection'</code>
-    </ArgumentTypeCoercion>
     <InvalidArgument occurrences="7">
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
@@ -2253,33 +1718,10 @@
       <code>testSearchSubtree</code>
       <code>testSerialize</code>
     </MissingReturnType>
-    <MixedArgument occurrences="13">
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$this-&gt;createDn('ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Test1,')</code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$attr</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="9">
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
+    <MixedAssignment occurrences="1">
       <code>$newObject</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="1">
@@ -2297,7 +1739,7 @@
       <code>$node-&gt;ou</code>
       <code>$node-&gt;ou</code>
     </PossiblyNullPropertyFetch>
-    <PossiblyNullReference occurrences="16">
+    <PossiblyNullReference occurrences="13">
       <code>countChildren</code>
       <code>countChildren</code>
       <code>countSubtree</code>
@@ -2306,9 +1748,6 @@
       <code>getDnString</code>
       <code>getParent</code>
       <code>getParent</code>
-      <code>isAttached</code>
-      <code>isAttached</code>
-      <code>isAttached</code>
       <code>isAttached</code>
       <code>reload</code>
       <code>searchChildren</code>
@@ -2327,11 +1766,7 @@
     </UnusedVariable>
   </file>
   <file src="test/Node/RootDseTest.php">
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="8">
-      <code>assertNullOrString</code>
+    <MissingReturnType occurrences="7">
       <code>testGetters</code>
       <code>testLoadRootDseNode</code>
       <code>testOffsetSetWillThrowException</code>
@@ -2388,10 +1823,6 @@
     </UndefinedMethod>
   </file>
   <file src="test/Node/SchemaTest.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>'Laminas\Ldap\Node\Schema\AttributeType\OpenLdap'</code>
-      <code>'Laminas\Ldap\Node\Schema\ObjectClass\OpenLdap'</code>
-    </ArgumentTypeCoercion>
     <MissingReturnType occurrences="13">
       <code>testActiveDirectorySchema</code>
       <code>testGetters</code>
@@ -2411,7 +1842,7 @@
       <code>$ou-&gt;_parents[0]</code>
       <code>$ou-&gt;_parents[0]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment occurrences="10">
       <code>$ca</code>
       <code>$ca2</code>
       <code>$cn</code>
@@ -2421,37 +1852,23 @@
       <code>$ob2</code>
       <code>$ob2</code>
       <code>$ou</code>
-      <code>$ou</code>
       <code>$schemaUn</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="25">
-      <code>getDescription</code>
-      <code>getDescription</code>
-      <code>getMaxLength</code>
+    <MixedMethodCall occurrences="12">
       <code>getMaxLength</code>
       <code>getMaxLength</code>
       <code>getMayContain</code>
       <code>getMayContain</code>
-      <code>getMayContain</code>
       <code>getMustContain</code>
       <code>getMustContain</code>
-      <code>getMustContain</code>
-      <code>getName</code>
-      <code>getName</code>
       <code>getOid</code>
       <code>getOid</code>
       <code>getOid</code>
       <code>getOid</code>
-      <code>getOid</code>
-      <code>getOid</code>
-      <code>getParentClasses</code>
       <code>getSyntax</code>
       <code>getSyntax</code>
-      <code>getSyntax</code>
-      <code>getType</code>
-      <code>isSingleValued</code>
     </MixedMethodCall>
-    <MixedPropertyFetch occurrences="48">
+    <MixedPropertyFetch occurrences="18">
       <code>$ca-&gt;may</code>
       <code>$ca-&gt;must</code>
       <code>$ca-&gt;sup</code>
@@ -2470,36 +1887,6 @@
       <code>$name-&gt;sup</code>
       <code>$name-&gt;syntax</code>
       <code>$name-&gt;{'max-length'}</code>
-      <code>$ou-&gt;_parents</code>
-      <code>$ou-&gt;_parents</code>
-      <code>$ou-&gt;_string</code>
-      <code>$ou-&gt;_string</code>
-      <code>$ou-&gt;abstract</code>
-      <code>$ou-&gt;aliases</code>
-      <code>$ou-&gt;aliases</code>
-      <code>$ou-&gt;auxiliary</code>
-      <code>$ou-&gt;collective</code>
-      <code>$ou-&gt;desc</code>
-      <code>$ou-&gt;desc</code>
-      <code>$ou-&gt;equality</code>
-      <code>$ou-&gt;may</code>
-      <code>$ou-&gt;must</code>
-      <code>$ou-&gt;name</code>
-      <code>$ou-&gt;name</code>
-      <code>$ou-&gt;obsolete</code>
-      <code>$ou-&gt;obsolete</code>
-      <code>$ou-&gt;oid</code>
-      <code>$ou-&gt;oid</code>
-      <code>$ou-&gt;ordering</code>
-      <code>$ou-&gt;structural</code>
-      <code>$ou-&gt;substr</code>
-      <code>$ou-&gt;sup</code>
-      <code>$ou-&gt;sup</code>
-      <code>$ou-&gt;syntax</code>
-      <code>$ou-&gt;usage</code>
-      <code>$ou-&gt;{'max-length'}</code>
-      <code>$ou-&gt;{'no-user-modification'}</code>
-      <code>$ou-&gt;{'single-value'}</code>
     </MixedPropertyFetch>
     <UndefinedMethod occurrences="3">
       <code>getLDAPSyntaxes</code>
@@ -2515,11 +1902,7 @@
     <InvalidMethodCall occurrences="1">
       <code>getDn</code>
     </InvalidMethodCall>
-    <MissingParamType occurrences="1">
-      <code>$entry</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="10">
-      <code>stripActiveDirectorySystemAttributes</code>
+    <MissingReturnType occurrences="9">
       <code>testAddDeletedNode</code>
       <code>testAddNewNode</code>
       <code>testModifyDeletedNode</code>
@@ -2530,81 +1913,14 @@
       <code>testMoveNode</code>
       <code>testSimpleUpdateOneValue</code>
     </MissingReturnType>
-    <MixedArgument occurrences="46">
+    <MixedArgument occurrences="3">
       <code>$child-&gt;getDn()</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$entry</code>
-      <code>$entry</code>
       <code>$entry['objectclass']</code>
       <code>$entry['objectclass']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="6">
-      <code>$entry[$attr]</code>
+    <MixedArrayAccess occurrences="1">
       <code>$entry['objectclass'][0]</code>
-      <code>$node2['dn']</code>
-      <code>$node2['dn']</code>
-      <code>$node2['dn']</code>
-      <code>$node2['dn']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
-      <code>$entry['objectclass']</code>
-    </MixedArrayAssignment>
-    <MixedAssignment occurrences="14">
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnNew</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-      <code>$dnOld</code>
-    </MixedAssignment>
     <PossiblyNullPropertyAssignment occurrences="2">
       <code>$node1</code>
       <code>$node1</code>
@@ -2620,118 +1936,39 @@
     </PossiblyNullReference>
   </file>
   <file src="test/OfflineReconnectTest.php">
-    <MissingReturnType occurrences="4">
-      <code>activateBindableOfflineMocks</code>
-      <code>reportErrorsAsConnectionFailure</code>
-      <code>testAddingAttributesReconnect</code>
-      <code>testRemovingAttributesReconnect</code>
-    </MissingReturnType>
-    <MixedMethodCall occurrences="3">
+    <PossiblyNullReference occurrences="3">
       <code>enable</code>
       <code>enable</code>
       <code>enable</code>
-    </MixedMethodCall>
+    </PossiblyNullReference>
   </file>
   <file src="test/OfflineTest.php">
-    <MissingParamType occurrences="15">
-      <code>$allowEmptyAttributes</code>
-      <code>$allowEmptyAttributes</code>
-      <code>$allowEmptyAttributes</code>
-      <code>$attributes</code>
-      <code>$attributes</code>
-      <code>$attributes</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$expectedAttributesToRemove</code>
-      <code>$expectedAttributesToRemove</code>
-      <code>$expectedAttributesToRemove</code>
-      <code>$expectedDn</code>
-      <code>$expectedDn</code>
-      <code>$expectedDn</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="9">
-      <code>removingAttributesProvider</code>
+    <MissingReturnType occurrences="5">
       <code>testAddingAttributes</code>
       <code>testAddingAttributesFails</code>
-      <code>testConfigObject</code>
-      <code>testOptionsGetter</code>
-      <code>testRemovingAttributes</code>
       <code>testRemovingAttributesFails</code>
       <code>testUpdatingAttributes</code>
       <code>testUpdatingAttributesFails</code>
     </MissingReturnType>
-    <MixedArgument occurrences="9">
-      <code>$allowEmptyAttributes</code>
-      <code>$allowEmptyAttributes</code>
-      <code>$allowEmptyAttributes</code>
-      <code>$attributes</code>
-      <code>$attributes</code>
-      <code>$attributes</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-    </MixedArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/ReconnectTest.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$options</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>non-empty-array&lt;string, string&gt;</code>
+    </InvalidReturnType>
     <InvalidScalarArgument occurrences="2">
       <code>getenv('TESTS_LAMINAS_LDAP_PORT')</code>
       <code>getenv('TESTS_LAMINAS_LDAP_PORT')</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="13">
-      <code>causeLdapConnectionFailure</code>
-      <code>getStandardOptions</code>
-      <code>testAddReconnect</code>
-      <code>testConnectParameterPreservation</code>
-      <code>testDeleteReconnect</code>
-      <code>testErroneousModificationDoesNotTriggerReconnect</code>
-      <code>testMultipleReconnectAttempts</code>
-      <code>testNoReconnectWhenNotRequested</code>
-      <code>testParametersOverridePropertiesDuringReconnect</code>
-      <code>testReconnectWhenRequested</code>
-      <code>testRenameReconnect</code>
-      <code>testUpdateReconnect</code>
-      <code>triggerReconnection</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="21">
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$new_dn</code>
-      <code>$new_dn</code>
-      <code>static::getStandardOptions()</code>
-    </MixedArgument>
     <MixedArrayAccess occurrences="4">
       <code>$entry['l'][0]</code>
       <code>$entry['uid'][0]</code>
       <code>$entry['uid'][0]</code>
       <code>$entry['uid'][0]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="7">
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$new_dn</code>
+    <MixedAssignment occurrences="1">
       <code>$options['port']</code>
     </MixedAssignment>
     <MixedOperand occurrences="1">
@@ -2754,17 +1991,10 @@
     </PossiblyFalseOperand>
   </file>
   <file src="test/SearchTest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>'\Laminas\Ldap\Collection\DefaultIterator'</code>
-    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="1">
       <code>assertNull</code>
     </DocblockTypeContradiction>
-    <MissingParamType occurrences="1">
-      <code>$attrib</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="45">
-      <code>customNaming</code>
+    <MissingReturnType occurrences="44">
       <code>testAttributeNameTreatmentCustomFunction</code>
       <code>testAttributeNameTreatmentCustomInstanceMethod</code>
       <code>testAttributeNameTreatmentCustomStaticMethod</code>
@@ -2810,58 +2040,16 @@
       <code>testUserIsAutomaticallyBoundOnOperationInDisconnectedState</code>
       <code>testUserIsAutomaticallyBoundOnOperationInUnboundState</code>
     </MissingReturnType>
-    <MixedArgument occurrences="26">
-      <code>$attrib</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn1</code>
-      <code>$dn1</code>
-      <code>$dn1</code>
-      <code>$dn1</code>
-      <code>$dn2</code>
+    <MixedArgument occurrences="2">
       <code>$entry['ou']</code>
       <code>$entry['ou']</code>
-      <code>$this-&gt;createDn('ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Node,')</code>
-      <code>$this-&gt;createDn('ou=Test1,')</code>
-      <code>$this-&gt;createDn('ou=Test2,')</code>
-      <code>$this-&gt;createDn('ou=Test99,')</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="3">
       <code>$item['l']</code>
       <code>$item['l']</code>
       <code>$item['l'][0]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="21">
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn</code>
-      <code>$dn1</code>
-      <code>$dn1</code>
-      <code>$dn1</code>
-      <code>$dn1</code>
-      <code>$dn2</code>
+    <MixedAssignment occurrences="3">
       <code>$item</code>
       <code>$item</code>
       <code>$item</code>
@@ -2946,7 +2134,7 @@
       <code>$b</code>
     </MissingClosureParamType>
     <MissingClosureReturnType occurrences="2">
-      <code>function ($a, $b) use ($lSorted) {</code>
+      <code>function ($a, $b) {</code>
       <code>function ($a, $b) {</code>
     </MissingClosureReturnType>
     <MissingReturnType occurrences="3">
@@ -2977,33 +2165,11 @@
       <code>$a</code>
       <code>$b</code>
     </UnusedClosureParam>
-    <UnusedVariable occurrences="1">
-      <code>$lSorted</code>
-    </UnusedVariable>
   </file>
   <file src="test/TestAsset/BuiltinFunctionMocks.php">
-    <MissingPropertyType occurrences="3">
-      <code>$ldap_bind_mock</code>
-      <code>$ldap_connect_mock</code>
-      <code>$ldap_set_option_mock</code>
-    </MissingPropertyType>
     <MissingReturnType occurrences="1">
       <code>createMocks</code>
     </MissingReturnType>
-  </file>
-  <file src="test/TestAsset/CustomNaming.php">
-    <MissingParamType occurrences="2">
-      <code>$attrib</code>
-      <code>$attrib</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="2">
-      <code>name1</code>
-      <code>name2</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$attrib</code>
-      <code>$attrib</code>
-    </MixedArgument>
   </file>
   <file src="test/bootstrap.php">
     <PossiblyFalseArgument occurrences="2">

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -5,6 +5,7 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorBaseline="psalm-baseline.xml"
+    findUnusedPsalmSuppress="true"
 >
     <projectFiles>
         <directory name="src"/>

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -3,24 +3,47 @@
 namespace Laminas\Ldap;
 
 use DateTime;
+use Traversable;
+
+use function array_keys;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function base64_encode;
+use function count;
+use function function_exists;
+use function iconv;
+use function in_array;
+use function is_array;
+use function is_int;
+use function is_scalar;
+use function is_string;
+use function mb_convert_encoding;
+use function md5;
+use function mt_rand;
+use function sha1;
+use function strlen;
+use function strtolower;
+use function substr;
+use function uniqid;
 
 /**
  * Laminas\Ldap\Attribute is a collection of LDAP attribute related functions.
  */
 class Attribute
 {
-    const PASSWORD_HASH_MD5   = 'md5';
-    const PASSWORD_HASH_SMD5  = 'smd5';
-    const PASSWORD_HASH_SHA   = 'sha';
-    const PASSWORD_HASH_SSHA  = 'ssha';
-    const PASSWORD_UNICODEPWD = 'unicodePwd';
+    public const PASSWORD_HASH_MD5   = 'md5';
+    public const PASSWORD_HASH_SMD5  = 'smd5';
+    public const PASSWORD_HASH_SHA   = 'sha';
+    public const PASSWORD_HASH_SSHA  = 'ssha';
+    public const PASSWORD_UNICODEPWD = 'unicodePwd';
 
     /**
      * Sets a LDAP attribute.
      *
      * @param  array                     $data
      * @param  string                    $attribName
-     * @param  string|array|\Traversable $value
+     * @param string|array|Traversable $value
      * @param  bool                   $append
      * @return void
      */
@@ -28,7 +51,7 @@ class Attribute
     {
         $attribName = strtolower($attribName);
         $valArray   = [];
-        if (is_array($value) || ($value instanceof \Traversable)) {
+        if (is_array($value) || $value instanceof Traversable) {
             foreach ($value as $v) {
                 $v = self::valueToLdap($v);
                 if ($v !== null) {
@@ -82,7 +105,7 @@ class Attribute
             }
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -277,7 +300,7 @@ class Attribute
      *
      * @param  array                      $data
      * @param  string                     $attribName
-     * @param  int|array|\Traversable $value
+     * @param int|array|Traversable $value
      * @param  bool                    $utc
      * @param  bool                    $append
      */
@@ -289,7 +312,7 @@ class Attribute
         $append = false
     ) {
         $convertedValues = [];
-        if (is_array($value) || ($value instanceof \Traversable)) {
+        if (is_array($value) || $value instanceof Traversable) {
             foreach ($value as $v) {
                 $v = self::valueToLdapDateTime($v, $utc);
                 if ($v !== null) {
@@ -312,11 +335,11 @@ class Attribute
      */
     private static function valueToLdapDateTime($value, $utc)
     {
-        if (is_int($value)) {
-            return Converter\Converter::toLdapDateTime($value, $utc);
+        if (! is_int($value)) {
+            return null;
         }
 
-        return;
+        return Converter\Converter::toLdapDateTime($value, $utc);
     }
 
     /**
@@ -355,14 +378,16 @@ class Attribute
     {
         if ($value instanceof DateTime) {
             return $value->format('U');
-        } elseif (is_string($value)) {
-            try {
-                return Converter\Converter::fromLdapDateTime($value, false)->format('U');
-            } catch (Converter\Exception\InvalidArgumentException $e) {
-                return;
-            }
         }
 
-        return;
+        if (! is_string($value)) {
+            return null;
+        }
+
+        try {
+            return Converter\Converter::fromLdapDateTime($value, false)->format('U');
+        } catch (Converter\Exception\InvalidArgumentException $e) {
+            return null;
+        }
     }
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -75,11 +75,12 @@ class Collection implements Iterator, Countable
      */
     public function getFirst()
     {
-        if ($this->count() > 0) {
-            $this->rewind();
-            return $this->current();
+        if ($this->count() < 1) {
+            return null;
         }
-        return null;
+
+        $this->rewind();
+        return $this->current();
     }
 
     /**
@@ -114,20 +115,23 @@ class Collection implements Iterator, Countable
     #[ReturnTypeWillChange]
     public function current()
     {
-        if ($this->count() > 0) {
-            if ($this->current < 0) {
-                $this->rewind();
-            }
-            if (! array_key_exists($this->current, $this->cache)) {
-                $current = $this->iterator->current();
-                if ($current === null) {
-                    return null;
-                }
-                $this->cache[$this->current] = $this->createEntry($current);
-            }
-            return $this->cache[$this->current];
+        if ($this->count() < 1) {
+            return null;
         }
-        return null;
+
+        if ($this->current < 0) {
+            $this->rewind();
+        }
+
+        if (! array_key_exists($this->current, $this->cache)) {
+            $current = $this->iterator->current();
+            if ($current === null) {
+                return null;
+            }
+            $this->cache[$this->current] = $this->createEntry($current);
+        }
+
+        return $this->cache[$this->current];
     }
 
     /**

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -4,6 +4,9 @@ namespace Laminas\Ldap;
 
 use Countable;
 use Iterator;
+use ReturnTypeWillChange;
+
+use function array_key_exists;
 
 /**
  * Laminas\Ldap\Collection wraps a list of LDAP entries.
@@ -15,7 +18,7 @@ class Collection implements Iterator, Countable
      *
      * @var Collection\DefaultIterator
      */
-    protected $iterator = null;
+    protected $iterator;
 
     /**
      * Current item number
@@ -31,11 +34,6 @@ class Collection implements Iterator, Countable
      */
     protected $cache = [];
 
-    /**
-     * Constructor.
-     *
-     * @param Collection\DefaultIterator $iterator
-     */
     public function __construct(Collection\DefaultIterator $iterator)
     {
         $this->iterator = $iterator;
@@ -73,7 +71,7 @@ class Collection implements Iterator, Countable
     /**
      * Get first entry
      *
-     * @return array
+     * @return array|null
      */
     public function getFirst()
     {
@@ -81,7 +79,7 @@ class Collection implements Iterator, Countable
             $this->rewind();
             return $this->current();
         }
-        return;
+        return null;
     }
 
     /**
@@ -100,7 +98,7 @@ class Collection implements Iterator, Countable
      *
      * @return int
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return $this->iterator->count();
@@ -113,7 +111,7 @@ class Collection implements Iterator, Countable
      * @return array|null
      * @throws Exception\LdapException
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function current()
     {
         if ($this->count() > 0) {
@@ -123,13 +121,13 @@ class Collection implements Iterator, Countable
             if (! array_key_exists($this->current, $this->cache)) {
                 $current = $this->iterator->current();
                 if ($current === null) {
-                    return;
+                    return null;
                 }
                 $this->cache[$this->current] = $this->createEntry($current);
             }
             return $this->cache[$this->current];
         }
-        return;
+        return null;
     }
 
     /**
@@ -156,7 +154,7 @@ class Collection implements Iterator, Countable
             }
             return $this->iterator->key();
         }
-        return;
+        return null;
     }
 
     /**
@@ -165,7 +163,7 @@ class Collection implements Iterator, Countable
      *
      * @return int|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function key()
     {
         if ($this->count() > 0) {
@@ -174,7 +172,7 @@ class Collection implements Iterator, Countable
             }
             return $this->current;
         }
-        return;
+        return null;
     }
 
     /**
@@ -183,7 +181,7 @@ class Collection implements Iterator, Countable
      *
      * @throws Exception\LdapException
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->iterator->next();
@@ -196,7 +194,7 @@ class Collection implements Iterator, Countable
      *
      * @throws Exception\LdapException
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->iterator->rewind();
@@ -210,7 +208,7 @@ class Collection implements Iterator, Countable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function valid()
     {
         if (isset($this->cache[$this->current])) {

--- a/src/Converter/Exception/ConverterException.php
+++ b/src/Converter/Exception/ConverterException.php
@@ -2,6 +2,8 @@
 
 namespace Laminas\Ldap\Converter\Exception;
 
-class ConverterException extends \Exception implements ExceptionInterface
+use Exception;
+
+class ConverterException extends Exception implements ExceptionInterface
 {
 }

--- a/src/Dn.php
+++ b/src/Dn.php
@@ -5,14 +5,40 @@ namespace Laminas\Ldap;
 use ArrayAccess;
 use ReturnTypeWillChange;
 
+use function array_change_key_case;
+use function array_keys;
+use function array_merge;
+use function array_pop;
+use function array_slice;
+use function array_splice;
+use function array_unshift;
+use function count;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_int;
+use function is_string;
+use function ksort;
+use function preg_match;
+use function str_replace;
+use function strlen;
+use function strtolower;
+use function strtoupper;
+use function substr;
+use function trim;
+
+use const CASE_LOWER;
+use const CASE_UPPER;
+use const SORT_STRING;
+
 /**
  * Laminas\Ldap\Dn provides an API for DN manipulation
  */
 class Dn implements ArrayAccess
 {
-    const ATTR_CASEFOLD_NONE  = 'none';
-    const ATTR_CASEFOLD_UPPER = 'upper';
-    const ATTR_CASEFOLD_LOWER = 'lower';
+    public const ATTR_CASEFOLD_NONE  = 'none';
+    public const ATTR_CASEFOLD_UPPER = 'upper';
+    public const ATTR_CASEFOLD_LOWER = 'lower';
 
     /**
      * The default case fold to use
@@ -102,7 +128,7 @@ class Dn implements ArrayAccess
      *
      * @param  string $caseFold
      * @return array
-     * @throws Exception\LdapException if DN has no RDN (empty array)
+     * @throws Exception\LdapException If DN has no RDN (empty array).
      */
     public function getRdn($caseFold = null)
     {
@@ -115,7 +141,7 @@ class Dn implements ArrayAccess
      *
      * @param  string $caseFold
      * @return string
-     * @throws Exception\LdapException if DN has no RDN (empty array)
+     * @throws Exception\LdapException If DN has no RDN (empty array).
      */
     public function getRdnString($caseFold = null)
     {
@@ -147,7 +173,7 @@ class Dn implements ArrayAccess
      * @param  int    $length
      * @param  string $caseFold
      * @return array
-     * @throws Exception\LdapException if index is illegal
+     * @throws Exception\LdapException If index is illegal.
      */
     public function get($index, $length = 1, $caseFold = null)
     {
@@ -169,7 +195,7 @@ class Dn implements ArrayAccess
      * @param  int   $index
      * @param  array $value
      * @return Dn Provides a fluent interface
-     * @throws Exception\LdapException if index is illegal
+     * @throws Exception\LdapException If index is illegal.
      */
     public function set($index, array $value)
     {
@@ -185,7 +211,7 @@ class Dn implements ArrayAccess
      * @param  int $index
      * @param  int $length
      * @return Dn Provides a fluent interface
-     * @throws Exception\LdapException if index is illegal
+     * @throws Exception\LdapException If index is illegal.
      */
     public function remove($index, $length = 1)
     {
@@ -230,7 +256,7 @@ class Dn implements ArrayAccess
      * @param  int   $index
      * @param  array $value
      * @return Dn Provides a fluent interface
-     * @throws Exception\LdapException if index is illegal
+     * @throws Exception\LdapException If index is illegal.
      */
     public function insert($index, array $value)
     {
@@ -264,7 +290,7 @@ class Dn implements ArrayAccess
      * Assert if value is in a correct RDN format
      *
      * @param  array $value
-     * @return bool
+     * @return void
      * @throws Exception\LdapException
      */
     protected static function assertRdn(array $value)
@@ -455,9 +481,9 @@ class Dn implements ArrayAccess
      * The characters ",", "+", """, "\", "<", ">", ";", "#", " = " with a special meaning in RFC 2252
      * are preceded by ba backslash. Control characters with an ASCII code < 32 are represented as \hexpair.
      * Finally all leading and trailing spaces are converted to sequences of \20.
-     * @see    Net_LDAP2_Util::escape_dn_value() from Benedikt Hallinger <beni@php.net>
+     *
      * @link   http://pear.php.net/package/Net_LDAP2
-     * @author Benedikt Hallinger <beni@php.net>
+     * @see    Net_LDAP2_Util::escape_dn_value() from Benedikt Hallinger <beni@php.net>
      *
      * @param  string|array $values An array containing the DN values that should be escaped
      * @return array The array $values, but escaped
@@ -483,15 +509,15 @@ class Dn implements ArrayAccess
                     $val = '\20' . $val;
                 }
                 for ($i = 0, $len = strlen($matches[3]); $i < $len; $i++) {
-                    $val = $val . '\20';
+                    $val .= '\20';
                 }
             }
             if (null === $val) {
-                $val = '\0';
-            } // apply escaped "null" if string is empty
+                $val = '\0'; // apply escaped "null" if string is empty
+            }
             $values[$key] = $val;
         }
-        return (count($values) == 1) ? $values[0] : $values;
+        return count($values) === 1 ? $values[0] : $values;
     }
 
     /**
@@ -499,9 +525,9 @@ class Dn implements ArrayAccess
      *
      * Any escape sequence starting with a baskslash - hexpair or special character -
      * will be transformed back to the corresponding character.
-     * @see    Net_LDAP2_Util::escape_dn_value() from Benedikt Hallinger <beni@php.net>
+     *
      * @link   http://pear.php.net/package/Net_LDAP2
-     * @author Benedikt Hallinger <beni@php.net>
+     * @see    Net_LDAP2_Util::escape_dn_value() from Benedikt Hallinger <beni@php.net>
      *
      * @param  string|array $values Array of DN Values
      * @return array Same as $values, but unescaped
@@ -515,12 +541,12 @@ class Dn implements ArrayAccess
             // strip slashes from special chars
             $val          = str_replace(
                 ['\\\\', '\,', '\+', '\"', '\<', '\>', '\;', '\#', '\='],
-                ['\\', ',', '+', '"', '<', '>', ';', '#', '=', ],
+                ['\\', ',', '+', '"', '<', '>', ';', '#', '='],
                 $val
             );
             $values[$key] = Converter\Converter::hex32ToAsc($val);
         }
-        return (count($values) == 1) ? $values[0] : $values;
+        return count($values) === 1 ? $values[0] : $values;
     }
 
     /**
@@ -544,8 +570,8 @@ class Dn implements ArrayAccess
      */
     public static function explodeDn(
         $dn,
-        array &$keys = null,
-        array &$vals = null,
+        ?array &$keys = null,
+        ?array &$vals = null,
         $caseFold = self::ATTR_CASEFOLD_NONE
     ) {
         $k = [];
@@ -585,8 +611,8 @@ class Dn implements ArrayAccess
      */
     public static function checkDn(
         $dn,
-        array &$keys = null,
-        array &$vals = null,
+        ?array &$keys = null,
+        ?array &$vals = null,
         $caseFold = self::ATTR_CASEFOLD_NONE
     ) {
         /* This is a classic state machine parser. Each iteration of the
@@ -603,14 +629,14 @@ class Dn implements ArrayAccess
         $ka    = [];
         $va    = [];
         for ($di = 0; $di <= $slen; $di++) {
-            $ch = ($di == $slen) ? 0 : $dn[$di];
+            $ch = $di === $slen ? 0 : $dn[$di];
             switch ($state) {
                 case 1: // collect key
                     if ($ch === '=') {
                         $key = trim(substr($dn, $ko, $di - $ko));
-                        if ($caseFold == self::ATTR_CASEFOLD_LOWER) {
+                        if ($caseFold === self::ATTR_CASEFOLD_LOWER) {
                             $key = strtolower($key);
-                        } elseif ($caseFold == self::ATTR_CASEFOLD_UPPER) {
+                        } elseif ($caseFold === self::ATTR_CASEFOLD_UPPER) {
                             $key = strtoupper($key);
                         }
                         if (is_array($multi)) {
@@ -667,7 +693,7 @@ class Dn implements ArrayAccess
             $vals = $va;
         }
 
-        return ($state === 1 && $ko > 0);
+        return $state === 1 && $ko > 0;
     }
 
     /**
@@ -737,14 +763,14 @@ class Dn implements ArrayAccess
             $keys = [];
             $vals = [];
             if ($childDn instanceof Dn) {
-                $cdn = $childDn->toArray(DN::ATTR_CASEFOLD_LOWER);
+                $cdn = $childDn->toArray(self::ATTR_CASEFOLD_LOWER);
             } else {
-                $cdn = static::explodeDn($childDn, $keys, $vals, DN::ATTR_CASEFOLD_LOWER);
+                $cdn = static::explodeDn($childDn, $keys, $vals, self::ATTR_CASEFOLD_LOWER);
             }
             if ($parentDn instanceof Dn) {
-                $pdn = $parentDn->toArray(DN::ATTR_CASEFOLD_LOWER);
+                $pdn = $parentDn->toArray(self::ATTR_CASEFOLD_LOWER);
             } else {
-                $pdn = static::explodeDn($parentDn, $keys, $vals, DN::ATTR_CASEFOLD_LOWER);
+                $pdn = static::explodeDn($parentDn, $keys, $vals, self::ATTR_CASEFOLD_LOWER);
             }
         } catch (Exception\LdapException $e) {
             return false;
@@ -755,7 +781,8 @@ class Dn implements ArrayAccess
             return false;
         }
         for ($i = 0, $count = count($pdn); $i < $count; $i++) {
-            if ($cdn[$i + $startIndex] != $pdn[$i]) {
+            //  do not force strict comparison via CS: unsafe here.
+            if ($cdn[$i + $startIndex] != $pdn[$i]) { // phpcs:ignore
                 return false;
             }
         }

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -2,16 +2,17 @@
 
 namespace Laminas\Ldap;
 
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_WARNING;
+
 /**
  * Handle Errors that might occur during execution of ldap_*-functions
- *
- * @package Laminas\Ldap\ErrorHandler
  */
 class ErrorHandler implements ErrorHandlerInterface
 {
-    /**
-     * @var ErrorHandlerInterface The Errror-Handler instance
-     */
+    /** @var ErrorHandlerInterface The Errror-Handler instance */
     protected static $errorHandler;
 
     /**
@@ -21,7 +22,6 @@ class ErrorHandler implements ErrorHandlerInterface
      * Error-constants like E_WARNING or E_NOTICE or E_WARNING ^ E_DEPRECATED
      *
      * @param int $level The Error-level(s) to handle by this ErrorHandler
-     *
      * @return void
      */
     public static function start($level = E_WARNING)
@@ -31,7 +31,6 @@ class ErrorHandler implements ErrorHandlerInterface
 
     /**
      * @param bool|false $throw
-     *
      * @return mixed
      */
     public static function stop($throw = false)
@@ -56,9 +55,9 @@ class ErrorHandler implements ErrorHandlerInterface
     /**
      * This method does nothing on purpose.
      *
-     * @param int $level
-     *
      * @see ErrorHandlerInterface::startErrorHandling()
+     *
+     * @param int $level
      * @return void
      */
     public function startErrorHandling($level = E_WARNING)
@@ -70,9 +69,9 @@ class ErrorHandler implements ErrorHandlerInterface
     /**
      * This method does nothing on purpose.
      *
-     * @param bool|false $throw
-     *
      * @see ErrorHandlerInterface::stopErrorHandling()
+     *
+     * @param bool|false $throw
      * @return void
      */
     public function stopErrorHandling($throw = false)
@@ -82,8 +81,6 @@ class ErrorHandler implements ErrorHandlerInterface
 
     /**
      * Set the error handler to be used
-     *
-     * @param ErrorHandlerInterface $errorHandler
      *
      * @return void
      */

--- a/src/ErrorHandlerInterface.php
+++ b/src/ErrorHandlerInterface.php
@@ -2,10 +2,10 @@
 
 namespace Laminas\Ldap;
 
+use const E_WARNING;
+
 /**
  * Handle Errors that might occur during execution of ldap_*-functions
- *
- * @package Laminas\Ldap\ErrorHandler
  */
 interface ErrorHandlerInterface
 {
@@ -13,7 +13,6 @@ interface ErrorHandlerInterface
      * Start the ErrorHandling-process
      *
      * @param int $level
-     *
      * @return void
      */
     public function startErrorHandling($level = E_WARNING);
@@ -25,7 +24,6 @@ interface ErrorHandlerInterface
      * be thrown as Exceptions or not
      *
      * @param bool|false $throw
-     *
      * @return mixed
      */
     public function stopErrorHandling($throw = false);

--- a/src/Exception/LdapException.php
+++ b/src/Exception/LdapException.php
@@ -2,98 +2,101 @@
 
 namespace Laminas\Ldap\Exception;
 
+use Exception;
 use Laminas\Ldap\Ldap;
 
-class LdapException extends \Exception implements ExceptionInterface
+use function dechex;
+
+class LdapException extends Exception implements ExceptionInterface
 {
-    const LDAP_SUCCESS                        = 0x00;
-    const LDAP_OPERATIONS_ERROR               = 0x01;
-    const LDAP_PROTOCOL_ERROR                 = 0x02;
-    const LDAP_TIMELIMIT_EXCEEDED             = 0x03;
-    const LDAP_SIZELIMIT_EXCEEDED             = 0x04;
-    const LDAP_COMPARE_FALSE                  = 0x05;
-    const LDAP_COMPARE_TRUE                   = 0x06;
-    const LDAP_AUTH_METHOD_NOT_SUPPORTED      = 0x07;
-    const LDAP_STRONG_AUTH_REQUIRED           = 0x08;
-    const LDAP_PARTIAL_RESULTS                = 0x09;
-    const LDAP_REFERRAL                       = 0x0a;
-    const LDAP_ADMINLIMIT_EXCEEDED            = 0x0b;
-    const LDAP_UNAVAILABLE_CRITICAL_EXTENSION = 0x0c;
-    const LDAP_CONFIDENTIALITY_REQUIRED       = 0x0d;
-    const LDAP_SASL_BIND_IN_PROGRESS          = 0x0e;
-    const LDAP_NO_SUCH_ATTRIBUTE              = 0x10;
-    const LDAP_UNDEFINED_TYPE                 = 0x11;
-    const LDAP_INAPPROPRIATE_MATCHING         = 0x12;
-    const LDAP_CONSTRAINT_VIOLATION           = 0x13;
-    const LDAP_TYPE_OR_VALUE_EXISTS           = 0x14;
-    const LDAP_INVALID_SYNTAX                 = 0x15;
-    const LDAP_NO_SUCH_OBJECT                 = 0x20;
-    const LDAP_ALIAS_PROBLEM                  = 0x21;
-    const LDAP_INVALID_DN_SYNTAX              = 0x22;
-    const LDAP_IS_LEAF                        = 0x23;
-    const LDAP_ALIAS_DEREF_PROBLEM            = 0x24;
-    const LDAP_PROXY_AUTHZ_FAILURE            = 0x2F;
-    const LDAP_INAPPROPRIATE_AUTH             = 0x30;
-    const LDAP_INVALID_CREDENTIALS            = 0x31;
-    const LDAP_INSUFFICIENT_ACCESS            = 0x32;
-    const LDAP_BUSY                           = 0x33;
-    const LDAP_UNAVAILABLE                    = 0x34;
-    const LDAP_UNWILLING_TO_PERFORM           = 0x35;
-    const LDAP_LOOP_DETECT                    = 0x36;
-    const LDAP_NAMING_VIOLATION               = 0x40;
-    const LDAP_OBJECT_CLASS_VIOLATION         = 0x41;
-    const LDAP_NOT_ALLOWED_ON_NONLEAF         = 0x42;
-    const LDAP_NOT_ALLOWED_ON_RDN             = 0x43;
-    const LDAP_ALREADY_EXISTS                 = 0x44;
-    const LDAP_NO_OBJECT_CLASS_MODS           = 0x45;
-    const LDAP_RESULTS_TOO_LARGE              = 0x46;
-    const LDAP_AFFECTS_MULTIPLE_DSAS          = 0x47;
-    const LDAP_OTHER                          = 0x50;
-    const LDAP_SERVER_DOWN                    = 0x51;
-    const LDAP_LOCAL_ERROR                    = 0x52;
-    const LDAP_ENCODING_ERROR                 = 0x53;
-    const LDAP_DECODING_ERROR                 = 0x54;
-    const LDAP_TIMEOUT                        = 0x55;
-    const LDAP_AUTH_UNKNOWN                   = 0x56;
-    const LDAP_FILTER_ERROR                   = 0x57;
-    const LDAP_USER_CANCELLED                 = 0x58;
-    const LDAP_PARAM_ERROR                    = 0x59;
-    const LDAP_NO_MEMORY                      = 0x5a;
-    const LDAP_CONNECT_ERROR                  = 0x5b;
-    const LDAP_NOT_SUPPORTED                  = 0x5c;
-    const LDAP_CONTROL_NOT_FOUND              = 0x5d;
-    const LDAP_NO_RESULTS_RETURNED            = 0x5e;
-    const LDAP_MORE_RESULTS_TO_RETURN         = 0x5f;
-    const LDAP_CLIENT_LOOP                    = 0x60;
-    const LDAP_REFERRAL_LIMIT_EXCEEDED        = 0x61;
-    const LDAP_CUP_RESOURCES_EXHAUSTED        = 0x71;
-    const LDAP_CUP_SECURITY_VIOLATION         = 0x72;
-    const LDAP_CUP_INVALID_DATA               = 0x73;
-    const LDAP_CUP_UNSUPPORTED_SCHEME         = 0x74;
-    const LDAP_CUP_RELOAD_REQUIRED            = 0x75;
-    const LDAP_CANCELLED                      = 0x76;
-    const LDAP_NO_SUCH_OPERATION              = 0x77;
-    const LDAP_TOO_LATE                       = 0x78;
-    const LDAP_CANNOT_CANCEL                  = 0x79;
-    const LDAP_ASSERTION_FAILED               = 0x7A;
-    const LDAP_SYNC_REFRESH_REQUIRED          = 0x1000;
-    const LDAP_X_SYNC_REFRESH_REQUIRED        = 0x4100;
-    const LDAP_X_NO_OPERATION                 = 0x410e;
-    const LDAP_X_ASSERTION_FAILED             = 0x410f;
-    const LDAP_X_NO_REFERRALS_FOUND           = 0x4110;
-    const LDAP_X_CANNOT_CHAIN                 = 0x4111;
+    public const LDAP_SUCCESS                        = 0x00;
+    public const LDAP_OPERATIONS_ERROR               = 0x01;
+    public const LDAP_PROTOCOL_ERROR                 = 0x02;
+    public const LDAP_TIMELIMIT_EXCEEDED             = 0x03;
+    public const LDAP_SIZELIMIT_EXCEEDED             = 0x04;
+    public const LDAP_COMPARE_FALSE                  = 0x05;
+    public const LDAP_COMPARE_TRUE                   = 0x06;
+    public const LDAP_AUTH_METHOD_NOT_SUPPORTED      = 0x07;
+    public const LDAP_STRONG_AUTH_REQUIRED           = 0x08;
+    public const LDAP_PARTIAL_RESULTS                = 0x09;
+    public const LDAP_REFERRAL                       = 0x0a;
+    public const LDAP_ADMINLIMIT_EXCEEDED            = 0x0b;
+    public const LDAP_UNAVAILABLE_CRITICAL_EXTENSION = 0x0c;
+    public const LDAP_CONFIDENTIALITY_REQUIRED       = 0x0d;
+    public const LDAP_SASL_BIND_IN_PROGRESS          = 0x0e;
+    public const LDAP_NO_SUCH_ATTRIBUTE              = 0x10;
+    public const LDAP_UNDEFINED_TYPE                 = 0x11;
+    public const LDAP_INAPPROPRIATE_MATCHING         = 0x12;
+    public const LDAP_CONSTRAINT_VIOLATION           = 0x13;
+    public const LDAP_TYPE_OR_VALUE_EXISTS           = 0x14;
+    public const LDAP_INVALID_SYNTAX                 = 0x15;
+    public const LDAP_NO_SUCH_OBJECT                 = 0x20;
+    public const LDAP_ALIAS_PROBLEM                  = 0x21;
+    public const LDAP_INVALID_DN_SYNTAX              = 0x22;
+    public const LDAP_IS_LEAF                        = 0x23;
+    public const LDAP_ALIAS_DEREF_PROBLEM            = 0x24;
+    public const LDAP_PROXY_AUTHZ_FAILURE            = 0x2F;
+    public const LDAP_INAPPROPRIATE_AUTH             = 0x30;
+    public const LDAP_INVALID_CREDENTIALS            = 0x31;
+    public const LDAP_INSUFFICIENT_ACCESS            = 0x32;
+    public const LDAP_BUSY                           = 0x33;
+    public const LDAP_UNAVAILABLE                    = 0x34;
+    public const LDAP_UNWILLING_TO_PERFORM           = 0x35;
+    public const LDAP_LOOP_DETECT                    = 0x36;
+    public const LDAP_NAMING_VIOLATION               = 0x40;
+    public const LDAP_OBJECT_CLASS_VIOLATION         = 0x41;
+    public const LDAP_NOT_ALLOWED_ON_NONLEAF         = 0x42;
+    public const LDAP_NOT_ALLOWED_ON_RDN             = 0x43;
+    public const LDAP_ALREADY_EXISTS                 = 0x44;
+    public const LDAP_NO_OBJECT_CLASS_MODS           = 0x45;
+    public const LDAP_RESULTS_TOO_LARGE              = 0x46;
+    public const LDAP_AFFECTS_MULTIPLE_DSAS          = 0x47;
+    public const LDAP_OTHER                          = 0x50;
+    public const LDAP_SERVER_DOWN                    = 0x51;
+    public const LDAP_LOCAL_ERROR                    = 0x52;
+    public const LDAP_ENCODING_ERROR                 = 0x53;
+    public const LDAP_DECODING_ERROR                 = 0x54;
+    public const LDAP_TIMEOUT                        = 0x55;
+    public const LDAP_AUTH_UNKNOWN                   = 0x56;
+    public const LDAP_FILTER_ERROR                   = 0x57;
+    public const LDAP_USER_CANCELLED                 = 0x58;
+    public const LDAP_PARAM_ERROR                    = 0x59;
+    public const LDAP_NO_MEMORY                      = 0x5a;
+    public const LDAP_CONNECT_ERROR                  = 0x5b;
+    public const LDAP_NOT_SUPPORTED                  = 0x5c;
+    public const LDAP_CONTROL_NOT_FOUND              = 0x5d;
+    public const LDAP_NO_RESULTS_RETURNED            = 0x5e;
+    public const LDAP_MORE_RESULTS_TO_RETURN         = 0x5f;
+    public const LDAP_CLIENT_LOOP                    = 0x60;
+    public const LDAP_REFERRAL_LIMIT_EXCEEDED        = 0x61;
+    public const LDAP_CUP_RESOURCES_EXHAUSTED        = 0x71;
+    public const LDAP_CUP_SECURITY_VIOLATION         = 0x72;
+    public const LDAP_CUP_INVALID_DATA               = 0x73;
+    public const LDAP_CUP_UNSUPPORTED_SCHEME         = 0x74;
+    public const LDAP_CUP_RELOAD_REQUIRED            = 0x75;
+    public const LDAP_CANCELLED                      = 0x76;
+    public const LDAP_NO_SUCH_OPERATION              = 0x77;
+    public const LDAP_TOO_LATE                       = 0x78;
+    public const LDAP_CANNOT_CANCEL                  = 0x79;
+    public const LDAP_ASSERTION_FAILED               = 0x7A;
+    public const LDAP_SYNC_REFRESH_REQUIRED          = 0x1000;
+    public const LDAP_X_SYNC_REFRESH_REQUIRED        = 0x4100;
+    public const LDAP_X_NO_OPERATION                 = 0x410e;
+    public const LDAP_X_ASSERTION_FAILED             = 0x410f;
+    public const LDAP_X_NO_REFERRALS_FOUND           = 0x4110;
+    public const LDAP_X_CANNOT_CHAIN                 = 0x4111;
 
     /* internal error code constants */
 
-    const LDAP_X_DOMAIN_MISMATCH      = 0x7001;
-    const LDAP_X_EXTENSION_NOT_LOADED = 0x7002;
+    public const LDAP_X_DOMAIN_MISMATCH      = 0x7001;
+    public const LDAP_X_EXTENSION_NOT_LOADED = 0x7002;
 
     /**
      * @param Ldap   $ldap Laminas\Ldap\Ldap object
      * @param string $str  Informative exception message
      * @param int    $code LDAP error code
      */
-    public function __construct(Ldap $ldap = null, $str = null, $code = 0)
+    public function __construct(?Ldap $ldap = null, $str = null, $code = 0)
     {
         $errorMessages = [];
         $message       = '';

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -2,17 +2,19 @@
 
 namespace Laminas\Ldap;
 
+use function func_get_args;
+
 /**
  * Laminas\Ldap\Filter.
  */
 class Filter extends Filter\StringFilter
 {
-    const TYPE_EQUALS         = '=';
-    const TYPE_GREATER        = '>';
-    const TYPE_GREATEROREQUAL = '>=';
-    const TYPE_LESS           = '<';
-    const TYPE_LESSOREQUAL    = '<=';
-    const TYPE_APPROX         = '~=';
+    public const TYPE_EQUALS         = '=';
+    public const TYPE_GREATER        = '>';
+    public const TYPE_GREATEROREQUAL = '>=';
+    public const TYPE_LESS           = '<';
+    public const TYPE_LESSOREQUAL    = '<=';
+    public const TYPE_APPROX         = '~=';
 
     /**
      * Creates an 'equals' filter.

--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -4,6 +4,12 @@ namespace Laminas\Ldap\Filter;
 
 use Laminas\Ldap\Converter\Converter;
 
+use function array_merge;
+use function count;
+use function func_get_args;
+use function is_array;
+use function str_replace;
+
 /**
  * Laminas\Ldap\Filter\AbstractFilter provides a base implementation for filters.
  */
@@ -18,6 +24,7 @@ abstract class AbstractFilter
 
     /**
      * Returns a string representation of the filter.
+     *
      * @see toString()
      *
      * @return string
@@ -69,9 +76,9 @@ abstract class AbstractFilter
      * Any control characters with an ACII code < 32 as well as the characters with special meaning in
      * LDAP filters "*", "(", ")", and "\" (the backslash) are converted into the representation of a
      * backslash followed by two hex digits representing the hexadecimal value of the character.
-     * @see    Net_LDAP2_Util::escape_filter_value() from Benedikt Hallinger <beni@php.net>
+     *
      * @link   http://pear.php.net/package/Net_LDAP2
-     * @author Benedikt Hallinger <beni@php.net>
+     * @see    Net_LDAP2_Util::escape_filter_value() from Benedikt Hallinger <beni@php.net>
      *
      * @param  string|array $values Array of values to escape
      * @return array Array $values, but escaped
@@ -91,16 +98,16 @@ abstract class AbstractFilter
             }
             $values[$key] = $val;
         }
-        return (count($values) == 1) ? $values[0] : $values;
+        return count($values) === 1 ? $values[0] : $values;
     }
 
     /**
      * Undoes the conversion done by {@link escapeValue()}.
      *
      * Converts any sequences of a backslash followed by two hex digits into the corresponding character.
-     * @see    Net_LDAP2_Util::escape_filter_value() from Benedikt Hallinger <beni@php.net>
+     *
      * @link   http://pear.php.net/package/Net_LDAP2
-     * @author Benedikt Hallinger <beni@php.net>
+     * @see    Net_LDAP2_Util::escape_filter_value() from Benedikt Hallinger <beni@php.net>
      *
      * @param  string|array $values Array of values to escape
      * @return array Array $values, but unescaped
@@ -114,6 +121,6 @@ abstract class AbstractFilter
             // Translate hex code into ascii
             $values[$key] = Converter::hex32ToAsc($value);
         }
-        return (count($values) == 1) ? $values[0] : $values;
+        return count($values) === 1 ? $values[0] : $values;
     }
 }

--- a/src/Filter/AbstractLogicalFilter.php
+++ b/src/Filter/AbstractLogicalFilter.php
@@ -2,13 +2,15 @@
 
 namespace Laminas\Ldap\Filter;
 
+use function is_string;
+
 /**
  * Laminas\Ldap\Filter\AbstractLogicalFilter provides a base implementation for a grouping filter.
  */
 abstract class AbstractLogicalFilter extends AbstractFilter
 {
-    const TYPE_AND = '&';
-    const TYPE_OR  = '|';
+    public const TYPE_AND = '&';
+    public const TYPE_OR  = '|';
 
     /**
      * All the sub-filters for this grouping filter.
@@ -36,7 +38,7 @@ abstract class AbstractLogicalFilter extends AbstractFilter
         foreach ($subfilters as $key => $s) {
             if (is_string($s)) {
                 $subfilters[$key] = new StringFilter($s);
-            } elseif (! ($s instanceof AbstractFilter)) {
+            } elseif (! $s instanceof AbstractFilter) {
                 throw new Exception\FilterException('Only strings or Laminas\Ldap\Filter\AbstractFilter allowed.');
             }
         }
@@ -47,7 +49,6 @@ abstract class AbstractLogicalFilter extends AbstractFilter
     /**
      * Adds a filter to this grouping filter.
      *
-     * @param  AbstractFilter $filter
      * @return AbstractLogicalFilter
      */
     public function addFilter(AbstractFilter $filter)

--- a/src/Filter/Exception/FilterException.php
+++ b/src/Filter/Exception/FilterException.php
@@ -2,6 +2,8 @@
 
 namespace Laminas\Ldap\Filter\Exception;
 
-class FilterException extends \Exception implements ExceptionInterface
+use Exception;
+
+class FilterException extends Exception implements ExceptionInterface
 {
 }

--- a/src/Filter/MaskFilter.php
+++ b/src/Filter/MaskFilter.php
@@ -2,6 +2,11 @@
 
 namespace Laminas\Ldap\Filter;
 
+use function array_shift;
+use function count;
+use function func_get_args;
+use function vsprintf;
+
 /**
  * Laminas\Ldap\Filter\MaskFilter provides a simple string filter to be used with a mask.
  */

--- a/src/Filter/NotFilter.php
+++ b/src/Filter/NotFilter.php
@@ -16,8 +16,6 @@ class NotFilter extends AbstractFilter
 
     /**
      * Creates a Laminas\Ldap\Filter\NotFilter.
-     *
-     * @param AbstractFilter $filter
      */
     public function __construct(AbstractFilter $filter)
     {

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -2,16 +2,25 @@
 
 namespace Laminas\Ldap;
 
+use LDAP\Connection;
+use LDAP\Result;
+use LDAP\ResultEntry;
+
+use function is_a;
+use function is_object;
+use function is_resource;
+use function version_compare;
+
+use const PHP_VERSION;
+
 /**
  * Laminas\Ldap\Handler is a collection of LDAP handler related functions.
  */
 class Handler
 {
-
     /**
-     * @param resource|\LDAP\Connection|\LDAP\Result|\LDAP\ResultEntry $handle
+     * @param resource|Connection|Result|ResultEntry $handle
      * @param string $handleClassName
-     * @return bool
      */
     private static function isHandle($handle, $handleClassName): bool
     {

--- a/src/Ldif/Encoder.php
+++ b/src/Ldif/Encoder.php
@@ -4,6 +4,32 @@ namespace Laminas\Ldap\Ldif;
 
 use Laminas\Ldap;
 
+use function array_change_key_case;
+use function array_key_exists;
+use function array_merge;
+use function base64_decode;
+use function base64_encode;
+use function chunk_split;
+use function count;
+use function explode;
+use function in_array;
+use function is_array;
+use function is_numeric;
+use function is_scalar;
+use function ksort;
+use function ord;
+use function preg_match;
+use function rtrim;
+use function sprintf;
+use function strlen;
+use function strtolower;
+use function substr;
+use function trim;
+
+use const CASE_LOWER;
+use const PHP_EOL;
+use const SORT_STRING;
+
 /**
  * Laminas\Ldap\Ldif\Encoder provides methods to encode and decode LDAP data into/from Ldif.
  */
@@ -17,17 +43,13 @@ class Encoder
     protected $options = [
         'sort'    => true,
         'version' => 1,
-        'wrap'    => 78
+        'wrap'    => 78,
     ];
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $versionWritten = false;
 
     /**
-     * Constructor.
-     *
      * @param  array $options Additional options used during encoding
      */
     protected function __construct(array $options = [])
@@ -57,9 +79,9 @@ class Encoder
     protected function _decode($string)
     {
         // @codingStandardsIgnoreEnd
-        $items = [];
-        $item  = [];
-        $last  = null;
+        $items     = [];
+        $item      = [];
+        $last      = null;
         $inComment = false;
         foreach (explode("\n", $string) as $line) {
             $line    = rtrim($line, "\x09\x0A\x0D\x00\x0B");
@@ -71,9 +93,9 @@ class Encoder
                 continue;
             } elseif (preg_match('/^([a-z0-9;-]+)(:[:<]?\s*)([^<]*)$/i', $line, $matches)) {
                 $inComment = false;
-                $name  = strtolower($matches[1]);
-                $type  = trim($matches[2]);
-                $value = $matches[3];
+                $name      = strtolower($matches[1]);
+                $type      = trim($matches[2]);
+                $value     = $matches[3];
                 if ($last !== null) {
                     $this->pushAttribute($last, $item);
                 }
@@ -93,7 +115,7 @@ class Encoder
         }
         $items[] = $item;
 
-        return (count($items) > 1) ? $items : $items[0];
+        return count($items) > 1 ? $items : $items[0];
     }
 
     /**
@@ -115,7 +137,7 @@ class Encoder
         } elseif (isset($entry[$name]) && $value !== '') {
             $entry[$name][] = $value;
         } else {
-            $entry[$name] = ($value !== '') ? [$value] : [];
+            $entry[$name] = $value !== '' ? [$value] : [];
         }
     }
 
@@ -152,7 +174,7 @@ class Encoder
             return $value->toLdif($this->options);
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -202,7 +224,7 @@ class Encoder
             }
         }
         // Test for ending space
-        if (substr($string, -1) == ' ') {
+        if (substr($string, -1) === ' ') {
             $base64 = true;
         }
 
@@ -264,10 +286,11 @@ class Encoder
     {
         $string     = '';
         $attributes = array_change_key_case($attributes, CASE_LOWER);
-        if (! $this->versionWritten && array_key_exists('dn', $attributes) && isset($this->options['version'])
+        if (
+            ! $this->versionWritten && array_key_exists('dn', $attributes) && isset($this->options['version'])
             && array_key_exists('objectclass', $attributes)
         ) {
-            $string .= sprintf('version: %d', $this->options['version']) . PHP_EOL;
+            $string              .= sprintf('version: %d', $this->options['version']) . PHP_EOL;
             $this->versionWritten = true;
         }
 

--- a/src/Node/AbstractNode.php
+++ b/src/Node/AbstractNode.php
@@ -4,26 +4,54 @@ namespace Laminas\Ldap\Node;
 
 use ArrayAccess;
 use Countable;
-use ReturnTypeWillChange;
 use Laminas\Ldap;
+use Laminas\Ldap\Dn;
 use Laminas\Ldap\Exception;
+use Laminas\Ldap\Exception\BadMethodCallException;
+use Laminas\Ldap\Exception\LdapException;
+
+use function array_key_exists;
+use function array_merge;
+use function count;
+use function in_array;
+use function json_encode;
+use function ksort;
+use function strtolower;
+
+use const SORT_STRING;
 
 /**
  * This class provides a base implementation for LDAP nodes
  */
 abstract class AbstractNode implements ArrayAccess, Countable
 {
-    protected static $systemAttributes = ['createtimestamp', 'creatorsname',
-                                               'entrycsn', 'entrydn', 'entryuuid', 'hassubordinates', 'modifiersname',
-                                               'modifytimestamp', 'structuralobjectclass', 'subschemasubentry',
-                                               'distinguishedname', 'instancetype', 'name', 'objectcategory',
-                                               'objectguid',
-                                               'usnchanged', 'usncreated', 'whenchanged', 'whencreated'];
+    /** @var non-empty-list<non-empty-string> */
+    protected static $systemAttributes = [
+        'createtimestamp',
+        'creatorsname',
+        'entrycsn',
+        'entrydn',
+        'entryuuid',
+        'hassubordinates',
+        'modifiersname',
+        'modifytimestamp',
+        'structuralobjectclass',
+        'subschemasubentry',
+        'distinguishedname',
+        'instancetype',
+        'name',
+        'objectcategory',
+        'objectguid',
+        'usnchanged',
+        'usncreated',
+        'whenchanged',
+        'whencreated',
+    ];
 
     /**
      * Holds the node's DN.
      *
-     * @var \Laminas\Ldap\Dn
+     * @var Dn
      */
     protected $dn;
 
@@ -35,11 +63,8 @@ abstract class AbstractNode implements ArrayAccess, Countable
     protected $currentData;
 
     /**
-     * Constructor.
-     *
      * Constructor is protected to enforce the use of factory methods.
      *
-     * @param  \Laminas\Ldap\Dn $dn
      * @param  array         $data
      * @param  bool       $fromDataSource
      */
@@ -67,10 +92,9 @@ abstract class AbstractNode implements ArrayAccess, Countable
      *
      * This is an online method.
      *
-     * @param  \Laminas\Ldap\Ldap $ldap
      * @return AbstractNode Provides a fluid interface
      */
-    public function reload(Ldap\Ldap $ldap = null)
+    public function reload(?Ldap\Ldap $ldap = null)
     {
         if ($ldap !== null) {
             $data = $ldap->getEntry($this->_getDn(), ['*', '+'], true);
@@ -85,7 +109,7 @@ abstract class AbstractNode implements ArrayAccess, Countable
      *
      * This is an offline method.
      *
-     * @return \Laminas\Ldap\Dn
+     * @return Dn
      */
     // @codingStandardsIgnoreStart
     protected function _getDn()
@@ -100,12 +124,11 @@ abstract class AbstractNode implements ArrayAccess, Countable
      *
      * This is an offline method.
      *
-     * @return \Laminas\Ldap\Dn
+     * @return Dn
      */
     public function getDn()
     {
-        $dn = clone $this->_getDn();
-        return $dn;
+        return clone $this->_getDn();
     }
 
     /**
@@ -304,11 +327,11 @@ abstract class AbstractNode implements ArrayAccess, Countable
      * @param  string  $name
      * @param  int $index
      * @return mixed
-     * @throws \Laminas\Ldap\Exception\LdapException
+     * @throws LdapException
      */
     public function getAttribute($name, $index = null)
     {
-        if ($name == 'dn') {
+        if ($name === 'dn') {
             return $this->getDnString();
         }
 
@@ -323,7 +346,7 @@ abstract class AbstractNode implements ArrayAccess, Countable
      * @param  string  $name
      * @param  int $index
      * @return array|int
-     * @throws \Laminas\Ldap\Exception\LdapException
+     * @throws LdapException
      */
     public function getDateTimeAttribute($name, $index = null)
     {
@@ -337,7 +360,7 @@ abstract class AbstractNode implements ArrayAccess, Countable
      *
      * @param  string $name
      * @param  mixed  $value
-     * @throws \Laminas\Ldap\Exception\BadMethodCallException
+     * @throws BadMethodCallException
      */
     public function __set($name, $value)
     {
@@ -351,7 +374,7 @@ abstract class AbstractNode implements ArrayAccess, Countable
      *
      * @param  string $name
      * @return mixed
-     * @throws \Laminas\Ldap\Exception\LdapException
+     * @throws LdapException
      */
     public function __get($name)
     {
@@ -365,8 +388,8 @@ abstract class AbstractNode implements ArrayAccess, Countable
      *
      * This is an offline method.
      *
-     * @param  $name
-     * @throws \Laminas\Ldap\Exception\BadMethodCallException
+     * @param  string $name
+     * @throws BadMethodCallException
      */
     public function __unset($name)
     {
@@ -394,7 +417,7 @@ abstract class AbstractNode implements ArrayAccess, Countable
      *
      * @param  string $name
      * @param  mixed  $value
-     * @throws \Laminas\Ldap\Exception\BadMethodCallException
+     * @throws BadMethodCallException
      */
     #[ReturnTypeWillChange]
     public function offsetSet($name, $value)
@@ -410,7 +433,7 @@ abstract class AbstractNode implements ArrayAccess, Countable
      *
      * @param  string $name
      * @return mixed
-     * @throws \Laminas\Ldap\Exception\LdapException
+     * @throws LdapException
      */
     #[ReturnTypeWillChange]
     public function offsetGet($name)
@@ -426,8 +449,8 @@ abstract class AbstractNode implements ArrayAccess, Countable
      *
      * This is an offline method.
      *
-     * @param  $name
-     * @throws \Laminas\Ldap\Exception\BadMethodCallException
+     * @param  string $name
+     * @throws BadMethodCallException
      */
     #[ReturnTypeWillChange]
     public function offsetUnset($name)

--- a/src/Node/ChildrenIterator.php
+++ b/src/Node/ChildrenIterator.php
@@ -6,7 +6,15 @@ use ArrayAccess;
 use Countable;
 use Iterator;
 use Laminas\Ldap;
+use Laminas\Ldap\Node;
 use RecursiveIterator;
+
+use function array_key_exists;
+use function count;
+use function current;
+use function key;
+use function next;
+use function reset;
 
 /**
  * Laminas\Ldap\Node\ChildrenIterator provides an iterator to a collection of children nodes.
@@ -21,10 +29,7 @@ class ChildrenIterator implements Iterator, Countable, RecursiveIterator, ArrayA
     private $data;
 
     /**
-     * Constructor.
-     *
      * @param array $data
-     * @return \Laminas\Ldap\Node\ChildrenIterator
      */
     public function __construct(array $data)
     {
@@ -46,7 +51,7 @@ class ChildrenIterator implements Iterator, Countable, RecursiveIterator, ArrayA
      * Return the current child.
      * Implements Iterator
      *
-     * @return \Laminas\Ldap\Node
+     * @return Node
      */
     public function current()
     {
@@ -91,7 +96,7 @@ class ChildrenIterator implements Iterator, Countable, RecursiveIterator, ArrayA
      */
     public function valid()
     {
-        return (current($this->data) !== false);
+        return current($this->data) !== false;
     }
 
     /**
@@ -120,7 +125,7 @@ class ChildrenIterator implements Iterator, Countable, RecursiveIterator, ArrayA
             return $this->current()->getChildren();
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -136,7 +141,7 @@ class ChildrenIterator implements Iterator, Countable, RecursiveIterator, ArrayA
             return $this->data[$rdn];
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -148,14 +153,15 @@ class ChildrenIterator implements Iterator, Countable, RecursiveIterator, ArrayA
      */
     public function offsetExists($rdn)
     {
-        return (array_key_exists($rdn, $this->data));
+        return array_key_exists($rdn, $this->data);
     }
 
     /**
      * Does nothing.
      * Implements ArrayAccess.
      *
-     * @param $name
+     * @param string $name
+     * @return void
      */
     public function offsetUnset($name)
     {
@@ -166,7 +172,8 @@ class ChildrenIterator implements Iterator, Countable, RecursiveIterator, ArrayA
      * Implements ArrayAccess.
      *
      * @param  string $name
-     * @param         $value
+     * @param  mixed  $value
+     * @return void
      */
     public function offsetSet($name, $value)
     {

--- a/src/Node/Collection.php
+++ b/src/Node/Collection.php
@@ -3,6 +3,7 @@
 namespace Laminas\Ldap\Node;
 
 use Laminas\Ldap;
+use Laminas\Ldap\Node;
 
 /**
  * Laminas\Ldap\Node\Collection provides a collection of nodes.
@@ -13,7 +14,7 @@ class Collection extends Ldap\Collection
      * Creates the data structure for the given entry data
      *
      * @param  array $data
-     * @return \Laminas\Ldap\Node
+     * @return Node
      */
     protected function createEntry(array $data)
     {

--- a/src/Node/RootDse.php
+++ b/src/Node/RootDse.php
@@ -3,21 +3,21 @@
 namespace Laminas\Ldap\Node;
 
 use Laminas\Ldap;
+use Laminas\Ldap\Dn;
 
 /**
  * Laminas\Ldap\Node\RootDse provides a simple data-container for the RootDse node.
  */
 class RootDse extends AbstractNode
 {
-    const SERVER_TYPE_GENERIC         = 1;
-    const SERVER_TYPE_OPENLDAP        = 2;
-    const SERVER_TYPE_ACTIVEDIRECTORY = 3;
-    const SERVER_TYPE_EDIRECTORY      = 4;
+    public const SERVER_TYPE_GENERIC         = 1;
+    public const SERVER_TYPE_OPENLDAP        = 2;
+    public const SERVER_TYPE_ACTIVEDIRECTORY = 3;
+    public const SERVER_TYPE_EDIRECTORY      = 4;
 
     /**
      * Factory method to create the RootDse.
      *
-     * @param \Laminas\Ldap\Ldap $ldap
      * @return RootDse
      */
     public static function create(Ldap\Ldap $ldap)
@@ -28,7 +28,8 @@ class RootDse extends AbstractNode
             return new RootDse\ActiveDirectory($dn, $data);
         } elseif (isset($data['dsaname'])) {
             return new RootDse\eDirectory($dn, $data);
-        } elseif (isset($data['structuralobjectclass'])
+        } elseif (
+            isset($data['structuralobjectclass'])
             && $data['structuralobjectclass'][0] === 'OpenLDAProotDSE'
         ) {
             return new RootDse\OpenLdap($dn, $data);
@@ -38,11 +39,8 @@ class RootDse extends AbstractNode
     }
 
     /**
-     * Constructor.
-     *
      * Constructor is protected to enforce the use of factory methods.
      *
-     * @param \Laminas\Ldap\Dn $dn
      * @param array         $data
      */
     protected function __construct(Ldap\Dn $dn, array $data)
@@ -105,7 +103,7 @@ class RootDse extends AbstractNode
     /**
      * Returns the schema DN
      *
-     * @return \Laminas\Ldap\Dn
+     * @return Dn
      */
     public function getSchemaDn()
     {

--- a/src/Node/RootDse/ActiveDirectory.php
+++ b/src/Node/RootDse/ActiveDirectory.php
@@ -3,6 +3,7 @@
 namespace Laminas\Ldap\Node\RootDse;
 
 use Laminas\Ldap;
+use Laminas\Ldap\Dn;
 use Laminas\Ldap\Node;
 
 /**
@@ -207,7 +208,7 @@ class ActiveDirectory extends Node\RootDse
     /**
      * Returns the schema DN
      *
-     * @return \Laminas\Ldap\Dn
+     * @return Dn
      */
     public function getSchemaDn()
     {

--- a/src/Node/Schema.php
+++ b/src/Node/Schema.php
@@ -9,15 +9,14 @@ use Laminas\Ldap;
  */
 class Schema extends AbstractNode
 {
-    const OBJECTCLASS_TYPE_UNKNOWN    = 0;
-    const OBJECTCLASS_TYPE_STRUCTURAL = 1;
-    const OBJECTCLASS_TYPE_ABSTRACT   = 3;
-    const OBJECTCLASS_TYPE_AUXILIARY  = 4;
+    public const OBJECTCLASS_TYPE_UNKNOWN    = 0;
+    public const OBJECTCLASS_TYPE_STRUCTURAL = 1;
+    public const OBJECTCLASS_TYPE_ABSTRACT   = 3;
+    public const OBJECTCLASS_TYPE_AUXILIARY  = 4;
 
     /**
      * Factory method to create the Schema node.
      *
-     * @param  \Laminas\Ldap\Ldap $ldap
      * @return Schema
      */
     public static function create(Ldap\Ldap $ldap)
@@ -36,13 +35,9 @@ class Schema extends AbstractNode
     }
 
     /**
-     * Constructor.
-     *
      * Constructor is protected to enforce the use of factory methods.
      *
-     * @param  \Laminas\Ldap\Dn   $dn
      * @param  array           $data
-     * @param  \Laminas\Ldap\Ldap $ldap
      */
     protected function __construct(Ldap\Dn $dn, array $data, Ldap\Ldap $ldap)
     {
@@ -53,8 +48,6 @@ class Schema extends AbstractNode
     /**
      * Parses the schema
      *
-     * @param  \Laminas\Ldap\Dn   $dn
-     * @param  \Laminas\Ldap\Ldap $ldap
      * @return Schema Provides a fluid interface
      */
     protected function parseSchema(Ldap\Dn $dn, Ldap\Ldap $ldap)

--- a/src/Node/Schema/AbstractItem.php
+++ b/src/Node/Schema/AbstractItem.php
@@ -5,6 +5,10 @@ namespace Laminas\Ldap\Node\Schema;
 use ArrayAccess;
 use Countable;
 use Laminas\Ldap\Exception;
+use Laminas\Ldap\Exception\BadMethodCallException;
+
+use function array_key_exists;
+use function count;
 
 /**
  * This class provides a base implementation for managing schema
@@ -20,8 +24,6 @@ abstract class AbstractItem implements ArrayAccess, Countable
     protected $data;
 
     /**
-     * Constructor.
-     *
      * @param array $data
      */
     public function __construct(array $data)
@@ -63,7 +65,7 @@ abstract class AbstractItem implements ArrayAccess, Countable
             return $this->data[$name];
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -74,7 +76,7 @@ abstract class AbstractItem implements ArrayAccess, Countable
      */
     public function __isset($name)
     {
-        return (array_key_exists($name, $this->data));
+        return array_key_exists($name, $this->data);
     }
 
     /**
@@ -85,7 +87,7 @@ abstract class AbstractItem implements ArrayAccess, Countable
      *
      * @param  string $name
      * @param  mixed  $value
-     * @throws \Laminas\Ldap\Exception\BadMethodCallException
+     * @throws BadMethodCallException
      */
     public function offsetSet($name, $value)
     {
@@ -110,7 +112,7 @@ abstract class AbstractItem implements ArrayAccess, Countable
      * This method is needed for a full implementation of ArrayAccess
      *
      * @param  string $name
-     * @throws \Laminas\Ldap\Exception\BadMethodCallException
+     * @throws BadMethodCallException
      */
     public function offsetUnset($name)
     {

--- a/src/Node/Schema/ActiveDirectory.php
+++ b/src/Node/Schema/ActiveDirectory.php
@@ -27,26 +27,28 @@ class ActiveDirectory extends Node\Schema
     /**
      * Parses the schema
      *
-     * @param \Laminas\Ldap\Dn   $dn
-     * @param \Laminas\Ldap\Ldap $ldap
      * @return ActiveDirectory Provides a fluid interface
      */
     protected function parseSchema(Ldap\Dn $dn, Ldap\Ldap $ldap)
     {
         parent::parseSchema($dn, $ldap);
-        foreach ($ldap->search(
-            '(objectClass=classSchema)',
-            $dn,
-            Ldap\Ldap::SEARCH_SCOPE_ONE
-        ) as $node) {
+        foreach (
+            $ldap->search(
+                '(objectClass=classSchema)',
+                $dn,
+                Ldap\Ldap::SEARCH_SCOPE_ONE
+            ) as $node
+        ) {
             $val                                  = new ObjectClass\ActiveDirectory($node);
             $this->objectClasses[$val->getName()] = $val;
         }
-        foreach ($ldap->search(
-            '(objectClass=attributeSchema)',
-            $dn,
-            Ldap\Ldap::SEARCH_SCOPE_ONE
-        ) as $node) {
+        foreach (
+            $ldap->search(
+                '(objectClass=attributeSchema)',
+                $dn,
+                Ldap\Ldap::SEARCH_SCOPE_ONE
+            ) as $node
+        ) {
             $val                                   = new AttributeType\ActiveDirectory($node);
             $this->attributeTypes[$val->getName()] = $val;
         }

--- a/src/Node/Schema/AttributeType/ActiveDirectory.php
+++ b/src/Node/Schema/AttributeType/ActiveDirectory.php
@@ -23,19 +23,21 @@ class ActiveDirectory extends Schema\AbstractItem implements AttributeTypeInterf
     /**
      * Gets the attribute OID
      *
-     * @return string
+     * @return null
      */
     public function getOid()
     {
+        return null;
     }
 
     /**
      * Gets the attribute syntax
      *
-     * @return string
+     * @return null
      */
     public function getSyntax()
     {
+        return null;
     }
 
     /**
@@ -45,23 +47,26 @@ class ActiveDirectory extends Schema\AbstractItem implements AttributeTypeInterf
      */
     public function getMaxLength()
     {
+        return null;
     }
 
     /**
      * Returns if the attribute is single-valued.
      *
-     * @return bool
+     * @return null
      */
     public function isSingleValued()
     {
+        return null;
     }
 
     /**
      * Gets the attribute description
      *
-     * @return string
+     * @return null
      */
     public function getDescription()
     {
+        return null;
     }
 }

--- a/src/Node/Schema/AttributeType/OpenLdap.php
+++ b/src/Node/Schema/AttributeType/OpenLdap.php
@@ -4,6 +4,8 @@ namespace Laminas\Ldap\Node\Schema\AttributeType;
 
 use Laminas\Ldap\Node\Schema;
 
+use function count;
+
 /**
  * Laminas\Ldap\Node\Schema\AttributeType\OpenLdap provides access to the attribute type
  * schema information on an OpenLDAP server.
@@ -100,6 +102,6 @@ class OpenLdap extends Schema\AbstractItem implements AttributeTypeInterface
             return $this->_parents[0];
         }
 
-        return;
+        return null;
     }
 }

--- a/src/Node/Schema/ObjectClass/ActiveDirectory.php
+++ b/src/Node/Schema/ObjectClass/ActiveDirectory.php
@@ -23,55 +23,61 @@ class ActiveDirectory extends Schema\AbstractItem implements ObjectClassInterfac
     /**
      * Gets the objectClass OID
      *
-     * @return string
+     * @return null
      */
     public function getOid()
     {
+        return null;
     }
 
     /**
      * Gets the attributes that this objectClass must contain
      *
-     * @return array
+     * @return null
      */
     public function getMustContain()
     {
+        return null;
     }
 
     /**
      * Gets the attributes that this objectClass may contain
      *
-     * @return array
+     * @return null
      */
     public function getMayContain()
     {
+        return null;
     }
 
     /**
      * Gets the objectClass description
      *
-     * @return string
+     * @return null
      */
     public function getDescription()
     {
+        return null;
     }
 
     /**
      * Gets the objectClass type
      *
-     * @return int
+     * @return null
      */
     public function getType()
     {
+        return null;
     }
 
     /**
      * Returns the parent objectClasses of this class.
      * This includes structural, abstract and auxiliary objectClasses
      *
-     * @return array
+     * @return null
      */
     public function getParentClasses()
     {
+        return null;
     }
 }

--- a/src/Node/Schema/ObjectClass/OpenLdap.php
+++ b/src/Node/Schema/ObjectClass/OpenLdap.php
@@ -4,6 +4,13 @@ namespace Laminas\Ldap\Node\Schema\ObjectClass;
 
 use Laminas\Ldap\Node\Schema;
 
+use function array_diff;
+use function array_merge;
+use function array_unique;
+use function sort;
+
+use const SORT_STRING;
+
 /**
  * Laminas\Ldap\Node\Schema\ObjectClass\OpenLdap provides access to the objectClass
  * schema information on an OpenLDAP server.
@@ -15,14 +22,14 @@ class OpenLdap extends Schema\AbstractItem implements ObjectClassInterface
      *
      * @var array
      */
-    protected $inheritedMust = null;
+    protected $inheritedMust;
 
     /**
      * All inherited "MAY" attributes
      *
      * @var array
      */
-    protected $inheritedMay = null;
+    protected $inheritedMay;
 
     /**
      * Gets the objectClass name

--- a/test/AbstractOnlineTestCase.php
+++ b/test/AbstractOnlineTestCase.php
@@ -1,17 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
 use Laminas\Ldap;
+
+use function array_reverse;
+use function getenv;
+use function substr;
 
 /**
  * @group      Laminas_Ldap
  */
 abstract class AbstractOnlineTestCase extends AbstractTestCase
 {
-    /**
-     * @var Ldap\Ldap
-     */
+    /** @var Ldap\Ldap */
     private static $ldap;
 
     public static function setUpBeforeClass(): void
@@ -22,7 +26,7 @@ abstract class AbstractOnlineTestCase extends AbstractTestCase
             'password' => getenv('TESTS_LAMINAS_LDAP_PASSWORD'),
             'baseDn'   => getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'),
         ];
-        if (getenv('TESTS_LAMINAS_LDAP_PORT') && getenv('TESTS_LAMINAS_LDAP_PORT') != 389) {
+        if (getenv('TESTS_LAMINAS_LDAP_PORT') && getenv('TESTS_LAMINAS_LDAP_PORT') !== '389') {
             $options['port'] = getenv('TESTS_LAMINAS_LDAP_PORT');
         }
         if (getenv('TESTS_LAMINAS_LDAP_USE_START_TLS')) {
@@ -55,9 +59,7 @@ abstract class AbstractOnlineTestCase extends AbstractTestCase
         }
     }
 
-    /**
-     * @var array
-     */
+    /** @var array<string, array<string, string>> */
     private $nodes;
 
     /**
@@ -70,6 +72,8 @@ abstract class AbstractOnlineTestCase extends AbstractTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         if (! getenv('TESTS_LAMINAS_LDAP_ONLINE_ENABLED')) {
             $this->markTestSkipped("Laminas_Ldap online tests are not enabled");
         }
@@ -77,49 +81,65 @@ abstract class AbstractOnlineTestCase extends AbstractTestCase
         $this->getLDAP()->bind();
     }
 
-    protected function createDn($dn)
+    protected function createDn(string $dn): string
     {
         if (substr($dn, -1) !== ',') {
             $dn .= ',';
         }
-        $dn = $dn . getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE');
+        $dn .= getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE');
 
         return Ldap\Dn::fromString($dn)->toString(Ldap\Dn::ATTR_CASEFOLD_LOWER);
     }
 
-    protected function prepareLDAPServer()
+    protected function prepareLDAPServer(): void
     {
         $this->nodes = [
-            $this->createDn('ou=Node,')          =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Node",
-                  "postalCode"  => "1234"],
-            $this->createDn('ou=Test1,ou=Node,') =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Test1"],
-            $this->createDn('ou=Test2,ou=Node,') =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Test2"],
-            $this->createDn('ou=Test1,')         =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Test1",
-                  "l"           => "e"],
-            $this->createDn('ou=Test2,')         =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Test2",
-                  "l"           => "d"],
-            $this->createDn('ou=Test3,')         =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Test3",
-                  "l"           => "c"],
-            $this->createDn('ou=Test4,')         =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Test4",
-                  "l"           => "b"],
-            $this->createDn('ou=Test5,')         =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Test5",
-                  "l"           => "a"],
+            $this->createDn('ou=Node,')
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Node",
+                "postalCode"  => "1234",
+            ],
+            $this->createDn('ou=Test1,ou=Node,')
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Test1",
+            ],
+            $this->createDn('ou=Test2,ou=Node,')
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Test2",
+            ],
+            $this->createDn('ou=Test1,')
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Test1",
+                "l"           => "e",
+            ],
+            $this->createDn('ou=Test2,')
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Test2",
+                "l"           => "d",
+            ],
+            $this->createDn('ou=Test3,')
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Test3",
+                "l"           => "c",
+            ],
+            $this->createDn('ou=Test4,')
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Test4",
+                "l"           => "b",
+            ],
+            $this->createDn('ou=Test5,')
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Test5",
+                "l"           => "a",
+            ],
         ];
 
         $ldap = $this->getLDAP()->getResource();

--- a/test/AbstractTestCase.php
+++ b/test/AbstractTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
 use Laminas\Ldap\Node;
@@ -15,7 +17,7 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function createTestArrayData()
     {
-        $data = [
+        return [
             'dn'          => 'cn=name,dc=example,dc=org',
             'cn'          => ['name'],
             'host'        => ['a', 'b', 'c'],
@@ -23,7 +25,6 @@ abstract class AbstractTestCase extends TestCase
             'boolean'     => ['TRUE', 'FALSE'],
             'objectclass' => ['account', 'top'],
         ];
-        return $data;
     }
 
     /**

--- a/test/CanonTest.php
+++ b/test/CanonTest.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
 use Laminas\Ldap;
 use Laminas\Ldap\Exception;
 use PHPUnit\Framework\TestCase;
+
+use function getenv;
+use function strstr;
 
 /* Note: The ldap_connect function does not actually try to connect. This
  * is why many tests attempt to bind with invalid credentials. If the
@@ -17,9 +22,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CanonTest extends TestCase
 {
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $options;
 
     protected function setUp(): void
@@ -260,8 +263,8 @@ class CanonTest extends TestCase
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
             $this->assertStringContainsString(
-                'Binding domain is not an authority for user: invalid@' .
-                    getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME'),
+                'Binding domain is not an authority for user: invalid@'
+                    . getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME'),
                 $zle->getMessage()
             );
         }
@@ -277,8 +280,8 @@ class CanonTest extends TestCase
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
             $this->assertStringContainsString(
-                'Binding domain is not an authority for user: ' .
-                    getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME_SHORT') . '\invalid',
+                'Binding domain is not an authority for user: '
+                    . getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME_SHORT') . '\invalid',
                 $zle->getMessage()
             );
         }
@@ -316,8 +319,8 @@ class CanonTest extends TestCase
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
             $this->assertStringContainsString(
-                'Invalid account name syntax: 0@' .
-                    getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME'),
+                'Invalid account name syntax: 0@'
+                    . getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME'),
                 $zle->getMessage()
             );
         }
@@ -330,8 +333,8 @@ class CanonTest extends TestCase
             $this->fail('Expected exception not thrown');
         } catch (Exception\LdapException $zle) {
             $this->assertStringContainsString(
-                'Invalid account name syntax: ' .
-                    getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME_SHORT') . '\\0',
+                'Invalid account name syntax: '
+                    . getenv('TESTS_LAMINAS_LDAP_ACCOUNT_DOMAIN_NAME_SHORT') . '\\0',
                 $zle->getMessage()
             );
         }

--- a/test/ChangePasswordTest.php
+++ b/test/ChangePasswordTest.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
 use Laminas\Ldap;
 use Laminas\Ldap\Exception;
 use Laminas\Ldap\Node;
+
+use function strstr;
 
 /**
  * @group      Laminas_Ldap
@@ -14,7 +18,8 @@ class ChangePasswordTest extends AbstractOnlineTestCase
 {
     public function testAddNewUserWithPasswordOpenLDAP()
     {
-        if ($this->getLDAP()->getRootDse()->getServerType() !==
+        if (
+            $this->getLDAP()->getRootDse()->getServerType() !==
             Node\RootDse::SERVER_TYPE_OPENLDAP
         ) {
             $this->markTestSkipped('Test can only be run on an OpenLDAP server');
@@ -36,7 +41,7 @@ class ChangePasswordTest extends AbstractOnlineTestCase
         try {
             $this->getLDAP()->add($dn, $data);
 
-            $this->assertInstanceOf('Laminas\Ldap\Ldap', $this->getLDAP()->bind($dn, $password));
+            $this->assertInstanceOf(\Laminas\Ldap\Ldap::class, $this->getLDAP()->bind($dn, $password));
 
             $this->getLDAP()->bind();
             $this->getLDAP()->delete($dn);
@@ -51,7 +56,8 @@ class ChangePasswordTest extends AbstractOnlineTestCase
 
     public function testChangePasswordWithUserAccountOpenLDAP()
     {
-        if ($this->getLDAP()->getRootDse()->getServerType() !==
+        if (
+            $this->getLDAP()->getRootDse()->getServerType() !==
             Node\RootDse::SERVER_TYPE_OPENLDAP
         ) {
             $this->markTestSkipped('Test can only be run on an OpenLDAP server');
@@ -94,7 +100,7 @@ class ChangePasswordTest extends AbstractOnlineTestCase
                         || strstr($message, 'Server is unwilling to perform'));
             }
 
-            $this->assertInstanceOf('Laminas\Ldap\Ldap', $this->getLDAP()->bind($dn, $newPasswd));
+            $this->assertInstanceOf(\Laminas\Ldap\Ldap::class, $this->getLDAP()->bind($dn, $newPasswd));
 
             $this->getLDAP()->bind();
             $this->getLDAP()->delete($dn);
@@ -109,7 +115,8 @@ class ChangePasswordTest extends AbstractOnlineTestCase
 
     public function testAddNewUserWithPasswordActiveDirectory()
     {
-        if ($this->getLDAP()->getRootDse()->getServerType() !==
+        if (
+            $this->getLDAP()->getRootDse()->getServerType() !==
             Node\RootDse::SERVER_TYPE_ACTIVEDIRECTORY
         ) {
             $this->markTestSkipped('Test can only be run on an ActiveDirectory server');
@@ -154,7 +161,8 @@ class ChangePasswordTest extends AbstractOnlineTestCase
 
     public function testChangePasswordWithUserAccountActiveDirectory()
     {
-        if ($this->getLDAP()->getRootDse()->getServerType() !==
+        if (
+            $this->getLDAP()->getRootDse()->getServerType() !==
             Node\RootDse::SERVER_TYPE_ACTIVEDIRECTORY
         ) {
             $this->markTestSkipped('Test can only be run on an ActiveDirectory server');
@@ -200,7 +208,7 @@ class ChangePasswordTest extends AbstractOnlineTestCase
                         || strstr($message, 'Server is unwilling to perform'));
             }
 
-            $this->assertInstanceOf('\Laminas\Ldap\Ldap', $this->getLDAP()->bind($dn, $newPasswd));
+            $this->assertInstanceOf(\Laminas\Ldap\Ldap::class, $this->getLDAP()->bind($dn, $newPasswd));
 
             $this->getLDAP()->bind();
             $this->getLDAP()->delete($dn);

--- a/test/ConnectTest.php
+++ b/test/ConnectTest.php
@@ -1,10 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
 use Laminas\Ldap;
 use Laminas\Ldap\Exception;
 use PHPUnit\Framework\TestCase;
+
+use function array_key_exists;
+use function array_merge;
+use function getenv;
+use function rand;
+use function strpos;
 
 /* Note: The ldap_connect function does not actually try to connect. This
  * is why many tests attempt to bind with invalid credentials. If the
@@ -17,7 +25,17 @@ use PHPUnit\Framework\TestCase;
  */
 class ConnectTest extends TestCase
 {
-    protected $options = null;
+    /**
+     * @var array{
+     *     host: string,
+     *     username: string,
+     *     password: string,
+     *     baseDn: string,
+     *     port?: numeric-string,
+     *     useSsl?: string|bool,
+     * }
+     */
+    protected $options;
 
     protected function setUp(): void
     {
@@ -31,7 +49,7 @@ class ConnectTest extends TestCase
             'password' => getenv('TESTS_LAMINAS_LDAP_PASSWORD'),
             'baseDn'   => getenv('TESTS_LAMINAS_LDAP_BASE_DN'),
         ];
-        if (getenv('TESTS_LAMINAS_LDAP_PORT') && getenv('TESTS_LAMINAS_LDAP_PORT') != 389) {
+        if (getenv('TESTS_LAMINAS_LDAP_PORT') && getenv('TESTS_LAMINAS_LDAP_PORT') !== '389') {
             $this->options['port'] = getenv('TESTS_LAMINAS_LDAP_PORT');
         }
         if (getenv('TESTS_LAMINAS_LDAP_USE_SSL')) {
@@ -39,7 +57,7 @@ class ConnectTest extends TestCase
         }
     }
 
-    public function testEmptyOptionsConnect()
+    public function testEmptyOptionsConnect(): void
     {
         $ldap = new Ldap\Ldap([]);
         try {
@@ -50,7 +68,7 @@ class ConnectTest extends TestCase
         }
     }
 
-    public function testUnknownHostConnect()
+    public function testUnknownHostConnect(): void
     {
         $ldap = new Ldap\Ldap(['host' => 'bogus.example.com']);
         try {
@@ -60,9 +78,9 @@ class ConnectTest extends TestCase
         } catch (Exception\LdapException $zle) {
             $alternatives = [
                 'Can\'t contact LDAP server',
-                'Failed to connect to LDAP server'
+                'Failed to connect to LDAP server',
             ];
-            $message = $zle->getMessage();
+            $message      = $zle->getMessage();
 
             foreach ($alternatives as $alternative) {
                 if (strpos($message, $alternative) !== false) {
@@ -75,7 +93,7 @@ class ConnectTest extends TestCase
         }
     }
 
-    public function testPlainConnect()
+    public function testPlainConnect(): void
     {
         $ldap = new Ldap\Ldap($this->options);
         try {
@@ -89,7 +107,7 @@ class ConnectTest extends TestCase
         }
     }
 
-    public function testNetworkTimeoutConnect()
+    public function testNetworkTimeoutConnect(): void
     {
         $networkTimeout = 1;
         $ldap           = new Ldap\Ldap(array_merge($this->options, ['networkTimeout' => $networkTimeout]));
@@ -99,11 +117,11 @@ class ConnectTest extends TestCase
         $this->assertEquals($networkTimeout, $actual);
     }
 
-    public function testExplicitParamsConnect()
+    public function testExplicitParamsConnect(): void
     {
         $host = getenv('TESTS_LAMINAS_LDAP_HOST');
         $port = 0;
-        if (getenv('TESTS_LAMINAS_LDAP_PORT') && getenv('TESTS_LAMINAS_LDAP_PORT') != 389) {
+        if (getenv('TESTS_LAMINAS_LDAP_PORT') && getenv('TESTS_LAMINAS_LDAP_PORT') !== '389') {
             $port = getenv('TESTS_LAMINAS_LDAP_PORT');
         }
         $useSsl = false;
@@ -121,7 +139,7 @@ class ConnectTest extends TestCase
         }
     }
 
-    public function testExplicitPortConnect()
+    public function testExplicitPortConnect(): void
     {
         $port = 389;
         if (getenv('TESTS_LAMINAS_LDAP_PORT') && getenv('TESTS_LAMINAS_LDAP_PORT')) {
@@ -141,7 +159,7 @@ class ConnectTest extends TestCase
         }
     }
 
-    public function testExplicitNetworkTimeoutConnect()
+    public function testExplicitNetworkTimeoutConnect(): void
     {
         $networkTimeout = rand(1, 100);
         if (array_key_exists('networkTimeout', $this->options)) {
@@ -155,7 +173,7 @@ class ConnectTest extends TestCase
         $this->assertEquals($networkTimeout, $actual);
     }
 
-    public function testBadPortConnect()
+    public function testBadPortConnect(): void
     {
         $options         = $this->options;
         $options['port'] = 10;
@@ -169,7 +187,7 @@ class ConnectTest extends TestCase
         }
     }
 
-    public function testSetOptionsConnect()
+    public function testSetOptionsConnect(): void
     {
         $ldap = new Ldap\Ldap();
         $ldap->setOptions($this->options);
@@ -181,7 +199,7 @@ class ConnectTest extends TestCase
         }
     }
 
-    public function testMultiConnect()
+    public function testMultiConnect(): void
     {
         $ldap = new Ldap\Ldap($this->options);
         for ($i = 0; $i < 3; $i++) {
@@ -194,7 +212,7 @@ class ConnectTest extends TestCase
         }
     }
 
-    public function testDisconnect()
+    public function testDisconnect(): void
     {
         $ldap = new Ldap\Ldap($this->options);
         for ($i = 0; $i < 3; $i++) {
@@ -208,7 +226,7 @@ class ConnectTest extends TestCase
         }
     }
 
-    public function testGetErrorCode()
+    public function testGetErrorCode(): void
     {
         $ldap = new Ldap\Ldap($this->options);
         try {
@@ -228,11 +246,11 @@ class ConnectTest extends TestCase
     /**
      * @group Laminas-8274
      */
-    public function testConnectWithUri()
+    public function testConnectWithUri(): void
     {
         $host = getenv('TESTS_LAMINAS_LDAP_HOST');
         $port = 0;
-        if (getenv('TESTS_LAMINAS_LDAP_PORT') && getenv('TESTS_LAMINAS_LDAP_PORT') != 389) {
+        if (getenv('TESTS_LAMINAS_LDAP_PORT') && getenv('TESTS_LAMINAS_LDAP_PORT') !== '389') {
             $port = getenv('TESTS_LAMINAS_LDAP_PORT');
         }
         $useSsl = false;
@@ -245,7 +263,7 @@ class ConnectTest extends TestCase
             $host = 'ldap://' . $host;
         }
         if ($port) {
-            $host = $host . ':' . $port;
+            $host .= ':' . $port;
         }
 
         $ldap = new Ldap\Ldap();
@@ -260,12 +278,13 @@ class ConnectTest extends TestCase
 
     /**
      * @see https://github.com/zendframework/zend-ldap/issues/19
+     *
      * @dataProvider connectionWithoutPortInOptionsArrayProvider
      */
-    public function testConnectionWithoutPortInOptionsArray($host, $ssl, $connectURI)
+    public function testConnectionWithoutPortInOptionsArray(string $host, bool $ssl, string $connectUri): void
     {
         $options = [
-            'host' => $host,
+            'host'   => $host,
             'useSsl' => $ssl,
         ];
 
@@ -275,11 +294,12 @@ class ConnectTest extends TestCase
         // The purpose of the test is to see that the $connectURI string is found
         // in the exception message.
         $this->expectException(Exception\LdapException::class);
-        $this->expectExceptionMessage($connectURI);
+        $this->expectExceptionMessage($connectUri);
         $ldap->bind();
     }
 
-    public function connectionWithoutPortInOptionsArrayProvider()
+    /** @return non-empty-list<array{string, bool, string}> */
+    public function connectionWithoutPortInOptionsArrayProvider(): array
     {
         // purposely set the host to something invalid so that the test will throw an exception
         $host = 'unknown';

--- a/test/Converter/ConverterTest.php
+++ b/test/Converter/ConverterTest.php
@@ -1,23 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Converter;
 
 use DateTime;
 use DateTimeZone;
+use InvalidArgumentException;
 use Laminas\Ldap\Converter\Converter;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use UnexpectedValueException;
+
+use function chr;
+use function date_timestamp_set;
+use function fopen;
+use function serialize;
+use function stream_get_contents;
 
 /**
  * @group      Laminas_Ldap
  */
 class ConverterTest extends TestCase
 {
-    public function testAsc2hex32()
+    public function testAsc2hex32(): void
     {
-        $expected = '\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19' .
-                    '\1a\1b\1c\1d\1e\1f !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`' .
-                    'abcdefghijklmnopqrstuvwxyz{|}~';
+        $expected = '\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19'
+                    . '\1a\1b\1c\1d\1e\1f !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`'
+                    . 'abcdefghijklmnopqrstuvwxyz{|}~';
         $str      = '';
         for ($i = 0; $i < 127; $i++) {
             $str .= chr($i);
@@ -25,60 +35,105 @@ class ConverterTest extends TestCase
         $this->assertEquals($expected, Converter::ascToHex32($str));
     }
 
-    public function testHex2asc()
+    public function testHex2asc(): void
     {
         $expected = '';
         for ($i = 0; $i < 127; $i++) {
             $expected .= chr($i);
         }
 
-        $str = '\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b' .
-               '\1c\1d\1e\1f !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefg' .
-               'hijklmnopqrstuvwxyz{|}~';
+        $str = '\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\10\11\12\13\14\15\16\17\18\19\1a\1b'
+               . '\1c\1d\1e\1f !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefg'
+               . 'hijklmnopqrstuvwxyz{|}~';
         $this->assertEquals($expected, Converter::hex32ToAsc($str));
     }
 
     /**
      * @dataProvider toLdapDateTimeProvider
+     * @param array{date: DateTime|int|string|bool, utc: bool} $convert
      */
-    public function testToLdapDateTime($convert, $expect)
+    public function testToLdapDateTime(array $convert, string $expect): void
     {
         $result = Converter::toLdapDatetime($convert['date'], $convert['utc']);
         $this->assertEquals($expect, $result);
     }
 
-    public function toLdapDateTimeProvider()
+    /** @return non-empty-list<array{array{date: DateTime|int|string|bool, utc: bool}, string}> */
+    public function toLdapDateTimeProvider(): array
     {
         $tz = new DateTimeZone('UTC');
         return [
-            [['date' => 0,
-                        'utc' => true], '19700101000000Z'],
-            [['date' => new DateTime('2010-05-12 13:14:45+0300', $tz),
-                        'utc' => false], '20100512131445+0300'],
-            [['date' => new DateTime('2010-05-12 13:14:45+0300', $tz),
-                        'utc' => true], '20100512101445Z'],
-            [['date' => '2010-05-12 13:14:45+0300',
-                        'utc' => false], '20100512131445+0300'],
-            [['date' => '2010-05-12 13:14:45+0300',
-                        'utc' => true], '20100512101445Z'],
-            [['date' => DateTime::createFromFormat(DateTime::ISO8601, '2010-05-12T13:14:45+0300'),
-                        'utc' => true], '20100512101445Z'],
-            [['date' => DateTime::createFromFormat(DateTime::ISO8601, '2010-05-12T13:14:45+0300'),
-                        'utc' => false], '20100512131445+0300'],
-            [['date' => date_timestamp_set(new DateTime(), 0),
-                        'utc' => true], '19700101000000Z'],
+            [
+                [
+                    'date' => 0,
+                    'utc'  => true,
+                ],
+                '19700101000000Z',
+            ],
+            [
+                [
+                    'date' => new DateTime('2010-05-12 13:14:45+0300', $tz),
+                    'utc'  => false,
+                ],
+                '20100512131445+0300',
+            ],
+            [
+                [
+                    'date' => new DateTime('2010-05-12 13:14:45+0300', $tz),
+                    'utc'  => true,
+                ],
+                '20100512101445Z',
+            ],
+            [
+                [
+                    'date' => '2010-05-12 13:14:45+0300',
+                    'utc'  => false,
+                ],
+                '20100512131445+0300',
+            ],
+            [
+                [
+                    'date' => '2010-05-12 13:14:45+0300',
+                    'utc'  => true,
+                ],
+                '20100512101445Z',
+            ],
+            [
+                [
+                    'date' => DateTime::createFromFormat(DateTime::ISO8601, '2010-05-12T13:14:45+0300'),
+                    'utc'  => true,
+                ],
+                '20100512101445Z',
+            ],
+            [
+                [
+                    'date' => DateTime::createFromFormat(DateTime::ISO8601, '2010-05-12T13:14:45+0300'),
+                    'utc'  => false,
+                ],
+                '20100512131445+0300',
+            ],
+            [
+                [
+                    'date' => date_timestamp_set(new DateTime(), 0),
+                    'utc'  => true,
+                ],
+                '19700101000000Z',
+            ],
         ];
     }
 
     /**
      * @dataProvider toLdapBooleanProvider
+     * @param  'TRUE'|'FALSE' $expect
+     * @param mixed           $convert
      */
-    public function testToLdapBoolean($expect, $convert)
+    public function testToLdapBoolean(string $expect, $convert): void
     {
         $this->assertEquals($expect, Converter::toLdapBoolean($convert));
     }
 
-    public function toLdapBooleanProvider()
+    /** @return non-empty-list<array{'TRUE'|'FALSE', mixed}> */
+    public function toLdapBooleanProvider(): array
     {
         return [
             ['TRUE', true],
@@ -93,88 +148,127 @@ class ConverterTest extends TestCase
 
     /**
      * @dataProvider toLdapSerializeProvider
+     * @param mixed $convert
      */
-    public function testToLdapSerialize($expect, $convert)
+    public function testToLdapSerialize(string $expect, $convert): void
     {
         $this->assertEquals($expect, Converter::toLdapSerialize($convert));
     }
 
-    public function toLdapSerializeProvider()
+    /** @return non-empty-list<array{string, mixed}> */
+    public function toLdapSerializeProvider(): array
     {
         return [
             ['N;', null],
             ['i:1;', 1],
             [serialize(new DateTime('@0')), new DateTime('@0')],
-            ['a:3:{i:0;s:4:"test";i:1;i:1;s:3:"foo";s:3:"bar";}', ['test', 1,
-                                                                             'foo' => 'bar']],
+            [
+                'a:3:{i:0;s:4:"test";i:1;i:1;s:3:"foo";s:3:"bar";}',
+                [
+                    'test',
+                    1,
+                    'foo' => 'bar',
+                ],
+            ],
         ];
     }
 
     /**
      * @dataProvider toLdapProvider
+     * @param array{value: mixed, type: int} $expect
      */
-    public function testToLdap($expect, $convert)
+    public function testToLdap($expect, array $convert): void
     {
         $this->assertEquals($expect, Converter::toLdap($convert['value'], $convert['type']));
     }
 
-    public function toLdapProvider()
+    /** @return non-empty-list<array{mixed, array{value: mixed, type: int}}> */
+    public function toLdapProvider(): array
     {
         return [
-            [null, [
-                'value' => null,
-                'type'  => 0,
-            ]],
-            ['19700101000000Z', [
-                'value' => 0,
-                'type' => 2,
-            ]],
-            ['0', [
-                'value' => 0,
-                'type' => 0,
-            ]],
-            ['FALSE', [
-                'value' => 0,
-                'type' => 1,
-            ]],
-            ['19700101000000Z', [
-                'value' => DateTime::createFromFormat(DateTime::ISO8601, '1970-01-01T00:00:00+0000'),
-                'type' => 0,
-            ]],
-            [Converter::toLdapBoolean(true), [
-                'value' => (bool) true,
-                'type' => 0
-            ]],
-            [Converter::toLdapSerialize(new stdClass()), [
-                'value' => new stdClass(),
-                'type' => 0,
-            ]],
-            [Converter::toLdapSerialize(['foo']), [
-                'value' => ['foo'],
-                'type' => 0,
-            ]],
-            [stream_get_contents(fopen(__FILE__, 'r')), [
-                'value' => fopen(__FILE__, 'r'),
-                'type' => 0,
-            ]],
+            [
+                null,
+                [
+                    'value' => null,
+                    'type'  => 0,
+                ],
+            ],
+            [
+                '19700101000000Z',
+                [
+                    'value' => 0,
+                    'type'  => 2,
+                ],
+            ],
+            [
+                '0',
+                [
+                    'value' => 0,
+                    'type'  => 0,
+                ],
+            ],
+            [
+                'FALSE',
+                [
+                    'value' => 0,
+                    'type'  => 1,
+                ],
+            ],
+            [
+                '19700101000000Z',
+                [
+                    'value' => DateTime::createFromFormat(DateTime::ISO8601, '1970-01-01T00:00:00+0000'),
+                    'type'  => 0,
+                ],
+            ],
+            [
+                Converter::toLdapBoolean(true),
+                [
+                    'value' => (bool) true,
+                    'type'  => 0,
+                ],
+            ],
+            [
+                Converter::toLdapSerialize(new stdClass()),
+                [
+                    'value' => new stdClass(),
+                    'type'  => 0,
+                ],
+            ],
+            [
+                Converter::toLdapSerialize(['foo']),
+                [
+                    'value' => ['foo'],
+                    'type'  => 0,
+                ],
+            ],
+            [
+                stream_get_contents(fopen(__FILE__, 'r')),
+                [
+                    'value' => fopen(__FILE__, 'r'),
+                    'type'  => 0,
+                ],
+            ],
         ];
     }
 
     /**
      * @dataProvider fromLdapUnserializeProvider
+     * @param mixed $expect
      */
-    public function testFromLdapUnserialize($expect, $convert)
+    public function testFromLdapUnserialize($expect, string $convert): void
     {
         $this->assertEquals($expect, Converter::fromLdapUnserialize($convert));
     }
 
-    public function testFromLdapUnserializeThrowsException()
+    public function testFromLdapUnserializeThrowsException(): void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         Converter::fromLdapUnserialize('--');
     }
 
-    public function fromLdapUnserializeProvider()
+    /** @return non-empty-list<array{mixed, non-empty-string}> */
+    public function fromLdapUnserializeProvider(): array
     {
         return [
             [null, 'N;'],
@@ -183,23 +277,16 @@ class ConverterTest extends TestCase
         ];
     }
 
-    public function testFromLdapBoolean()
+    public function testFromLdapBoolean(): void
     {
         $this->assertTrue(Converter::fromLdapBoolean('TRUE'));
         $this->assertFalse(Converter::fromLdapBoolean('FALSE'));
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Converter::fromLdapBoolean('test');
     }
 
-    /**
-     * @dataProvider fromLdapDateTimeProvider
-     *
-     * @param DateTime $expected
-     * @param string   $convert
-     * @param  bool  $utc
-     * @return void
-     */
-    public function testFromLdapDateTime($expected, $convert, $utc)
+    /** @dataProvider fromLdapDateTimeProvider */
+    public function testFromLdapDateTime(DateTime $expected, string $convert, bool $utc): void
     {
         if (true === $utc) {
             $expected->setTimezone(new DateTimeZone('UTC'));
@@ -207,7 +294,8 @@ class ConverterTest extends TestCase
         $this->assertEquals($expected, Converter::fromLdapDatetime($convert, $utc));
     }
 
-    public function fromLdapDateTimeProvider()
+    /** @return non-empty-list<array{DateTime, string, bool}> */
+    public function fromLdapDateTimeProvider(): array
     {
         return [
             [new DateTime('2010-12-24 08:00:23+0300'), '20101224080023+0300', false],
@@ -223,16 +311,17 @@ class ConverterTest extends TestCase
     }
 
     /**
-     *
      * @dataProvider         fromLdapDateTimeException
+     * @param mixed $value
      */
     public function testFromLdapDateTimeThrowsException($value)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Converter::fromLdapDatetime($value);
     }
 
-    public static function fromLdapDateTimeException()
+    /** @return non-empty-list<array{non-empty-string}> */
+    public static function fromLdapDateTimeException(): array
     {
         return [
             ['foobar'],
@@ -249,13 +338,16 @@ class ConverterTest extends TestCase
 
     /**
      * @dataProvider fromLdapProvider
+     * @param mixed $expect
+     * @param mixed $value
      */
-    public function testFromLdap($expect, $value, $type, $dateTimeAsUtc)
+    public function testFromLdap($expect, $value, int $type, bool $dateTimeAsUtc): void
     {
         $this->assertSame($expect, Converter::fromLdap($value, $type, $dateTimeAsUtc));
     }
 
-    public function fromLdapProvider()
+    /** @return non-empty-list<array{mixed, mixed, int, true}> */
+    public function fromLdapProvider(): array
     {
         return [
             ['1', '1', 0, true],

--- a/test/CopyRenameTest.php
+++ b/test/CopyRenameTest.php
@@ -1,39 +1,31 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
 use Laminas\Ldap;
 use Laminas\Ldap\Exception\LdapException;
+
+use function getenv;
 
 /**
  * @group      Laminas_Ldap
  */
 class CopyRenameTest extends AbstractOnlineTestCase
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $orgDn;
-    /**
-     * @var string
-     */
+    /** @var string */
     private $newDn;
-    /**
-     * @var string
-     */
+    /** @var string */
     private $orgSubTreeDn;
-    /**
-     * @var string
-     */
+    /** @var string */
     private $newSubTreeDn;
-    /**
-     * @var string
-     */
+    /** @var string */
     private $targetSubTreeDn;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $nodes;
 
     protected function setUp(): void
@@ -48,30 +40,48 @@ class CopyRenameTest extends AbstractOnlineTestCase
         $this->targetSubTreeDn = $this->createDn('ou=Target,');
 
         $this->nodes = [
-            $this->orgDn        => ["objectClass" => "organizationalUnit",
-                                         "ou"          => "OrgTest"],
-            $this->orgSubTreeDn => ["objectClass" => "organizationalUnit",
-                                         "ou"          => "OrgSubtree"],
-            'ou=Subtree1,' . $this->orgSubTreeDn              =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Subtree1"],
-            'ou=Subtree11,ou=Subtree1,' . $this->orgSubTreeDn =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Subtree11"],
-            'ou=Subtree12,ou=Subtree1,' . $this->orgSubTreeDn =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Subtree12"],
-            'ou=Subtree13,ou=Subtree1,' . $this->orgSubTreeDn =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Subtree13"],
-            'ou=Subtree2,' . $this->orgSubTreeDn              =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Subtree2"],
-            'ou=Subtree3,' . $this->orgSubTreeDn              =>
-            ["objectClass" => "organizationalUnit",
-                  "ou"          => "Subtree3"],
-            $this->targetSubTreeDn => ["objectClass" => "organizationalUnit",
-                                            "ou"          => "Target"]
+            $this->orgDn        => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "OrgTest",
+            ],
+            $this->orgSubTreeDn => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "OrgSubtree",
+            ],
+            'ou=Subtree1,' . $this->orgSubTreeDn
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Subtree1",
+            ],
+            'ou=Subtree11,ou=Subtree1,' . $this->orgSubTreeDn
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Subtree11",
+            ],
+            'ou=Subtree12,ou=Subtree1,' . $this->orgSubTreeDn
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Subtree12",
+            ],
+            'ou=Subtree13,ou=Subtree1,' . $this->orgSubTreeDn
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Subtree13",
+            ],
+            'ou=Subtree2,' . $this->orgSubTreeDn
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Subtree2",
+            ],
+            'ou=Subtree3,' . $this->orgSubTreeDn
+            => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Subtree3",
+            ],
+            $this->targetSubTreeDn => [
+                "objectClass" => "organizationalUnit",
+                "ou"          => "Target",
+            ],
         ];
 
         $ldap = $this->getLDAP()->getResource();
@@ -100,7 +110,6 @@ class CopyRenameTest extends AbstractOnlineTestCase
         if ($this->getLDAP()->exists($this->targetSubTreeDn)) {
             $this->getLDAP()->delete($this->targetSubTreeDn, true);
         }
-
 
         $this->cleanupLDAPServer();
         parent::tearDown();

--- a/test/CrudTest.php
+++ b/test/CrudTest.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
+use InvalidArgumentException;
 use Laminas\Ldap;
-use Laminas\Ldap\Exception;
 use Laminas\Ldap\Exception\LdapException;
+use stdClass;
+
+use function array_merge;
 
 /**
  * @group      Laminas_Ldap
@@ -16,7 +21,7 @@ class CrudTest extends AbstractOnlineTestCase
         $dn   = $this->createDn('ou=TestCreated,');
         $data = [
             'ou'          => 'TestCreated',
-            'objectClass' => 'organizationalUnit'
+            'objectClass' => 'organizationalUnit',
         ];
         try {
             $this->getLDAP()->add($dn, $data);
@@ -37,7 +42,7 @@ class CrudTest extends AbstractOnlineTestCase
         $data = [
             'ou'          => 'TestCreated',
             'l'           => 'mylocation1',
-            'objectClass' => 'organizationalUnit'
+            'objectClass' => 'organizationalUnit',
         ];
         try {
             $this->getLDAP()->add($dn, $data);
@@ -61,7 +66,7 @@ class CrudTest extends AbstractOnlineTestCase
         $dn   = $this->createDn('ou=TestCreated,ou=Node2,');
         $data = [
             'ou'          => 'TestCreated',
-            'objectClass' => 'organizationalUnit'
+            'objectClass' => 'organizationalUnit',
         ];
         $this->expectException(LdapException::class);
         $this->getLDAP()->add($dn, $data);
@@ -72,7 +77,7 @@ class CrudTest extends AbstractOnlineTestCase
         $dn   = $this->createDn('ou=TestCreated,');
         $data = [
             'ou'          => 'TestCreated',
-            'objectclass' => 'organizationalUnit'
+            'objectclass' => 'organizationalUnit',
         ];
         try {
             $this->getLDAP()->add($dn, $data);
@@ -111,21 +116,26 @@ class CrudTest extends AbstractOnlineTestCase
     {
         $topDn = $this->createDn('ou=RecursiveTest,');
         $dn    = $topDn;
-        $data  = ['ou'          => 'RecursiveTest',
-                       'objectclass' => 'organizationalUnit'
+        $data  = [
+            'ou'          => 'RecursiveTest',
+            'objectclass' => 'organizationalUnit',
         ];
         $this->getLDAP()->add($dn, $data);
         for ($level = 1; $level <= 5; $level++) {
             $name = 'Level' . $level;
             $dn   = 'ou=' . $name . ',' . $dn;
-            $data = ['ou'          => $name,
-                          'objectclass' => 'organizationalUnit'];
+            $data = [
+                'ou'          => $name,
+                'objectclass' => 'organizationalUnit',
+            ];
             $this->getLDAP()->add($dn, $data);
             for ($item = 1; $item <= 5; $item++) {
                 $uid   = 'Item' . $item;
                 $idn   = 'ou=' . $uid . ',' . $dn;
-                $idata = ['ou'          => $uid,
-                               'objectclass' => 'organizationalUnit'];
+                $idata = [
+                    'ou'          => $uid,
+                    'objectclass' => 'organizationalUnit',
+                ];
                 $this->getLDAP()->add($idn, $idata);
             }
         }
@@ -147,8 +157,10 @@ class CrudTest extends AbstractOnlineTestCase
     public function testSave()
     {
         $dn   = $this->createDn('ou=TestCreated,');
-        $data = ['ou'          => 'TestCreated',
-                      'objectclass' => 'organizationalUnit'];
+        $data = [
+            'ou'          => 'TestCreated',
+            'objectclass' => 'organizationalUnit',
+        ];
         try {
             $this->getLDAP()->save($dn, $data);
             $this->assertTrue($this->getLDAP()->exists($dn));
@@ -177,7 +189,8 @@ class CrudTest extends AbstractOnlineTestCase
             'a6' => ['account'],
             'a7' => [null],
             'a8' => [''],
-            'a9' => ['', null, 'account', '', null, 'TestCreated', '', null]];
+            'a9' => ['', null, 'account', '', null, 'TestCreated', '', null],
+        ];
         Ldap\Ldap::prepareLDAPEntryArray($data);
         $expected = [
             'a1' => ['TestCreated'],
@@ -188,7 +201,8 @@ class CrudTest extends AbstractOnlineTestCase
             'a6' => ['account'],
             'a7' => [],
             'a8' => [],
-            'a9' => ['account', 'TestCreated']];
+            'a9' => ['account', 'TestCreated'],
+        ];
         $this->assertEquals($expected, $data);
     }
 
@@ -216,7 +230,7 @@ class CrudTest extends AbstractOnlineTestCase
             'null'         => [],
             'empty'        => [],
             'nullarray'    => [],
-            'emptyarray'   => []
+            'emptyarray'   => [],
         ];
         $this->assertEquals($expected, $data);
     }
@@ -224,18 +238,20 @@ class CrudTest extends AbstractOnlineTestCase
     public function testPrepareLDAPEntryArrayArrayData()
     {
         $data = [
-            'a1' => [['account']]];
-        $this->expectException(\InvalidArgumentException::class);
+            'a1' => [['account']],
+        ];
+        $this->expectException(InvalidArgumentException::class);
         Ldap\Ldap::prepareLDAPEntryArray($data);
     }
 
     public function testPrepareLDAPEntryArrayObjectData()
     {
-        $class    = new \stdClass();
+        $class    = new stdClass();
         $class->a = 'b';
         $data     = [
-            'a1' => [$class]];
-        $this->expectException(\InvalidArgumentException::class);
+            'a1' => [$class],
+        ];
+        $this->expectException(InvalidArgumentException::class);
         Ldap\Ldap::prepareLDAPEntryArray($data);
     }
 
@@ -244,7 +260,7 @@ class CrudTest extends AbstractOnlineTestCase
         $dn   = Ldap\Dn::fromString($this->createDn('ou=TestCreated,'));
         $data = [
             'ou'          => 'TestCreated',
-            'objectclass' => 'organizationalUnit'
+            'objectclass' => 'organizationalUnit',
         ];
         try {
             $this->getLDAP()->add($dn, $data);
@@ -261,7 +277,7 @@ class CrudTest extends AbstractOnlineTestCase
         $data = [
             'ou'          => 'TestCreated',
             'l'           => 'mylocation1',
-            'objectclass' => 'organizationalUnit'
+            'objectclass' => 'organizationalUnit',
         ];
         try {
             $this->getLDAP()->add($dn, $data);
@@ -280,8 +296,10 @@ class CrudTest extends AbstractOnlineTestCase
     public function testSaveWithDnObject()
     {
         $dn   = Ldap\Dn::fromString($this->createDn('ou=TestCreated,'));
-        $data = ['ou'          => 'TestCreated',
-                      'objectclass' => 'organizationalUnit'];
+        $data = [
+            'ou'          => 'TestCreated',
+            'objectclass' => 'organizationalUnit',
+        ];
         try {
             $this->getLDAP()->save($dn, $data);
             $this->assertTrue($this->getLDAP()->exists($dn));
@@ -305,7 +323,7 @@ class CrudTest extends AbstractOnlineTestCase
         $data = [
             'ou'          => 'TestCreated',
             'l'           => 'mylocation1',
-            'objectClass' => 'organizationalUnit'
+            'objectClass' => 'organizationalUnit',
         ];
         try {
             $this->getLDAP()->add($dn, $data);
@@ -334,7 +352,7 @@ class CrudTest extends AbstractOnlineTestCase
             'associatedDomain' => 'domain',
             'ou'               => 'TestCreated',
             'l'                => 'mylocation1',
-            'objectClass'      => ['organizationalUnit', 'domainRelatedObject']
+            'objectClass'      => ['organizationalUnit', 'domainRelatedObject'],
         ];
         try {
             $this->getLDAP()->add($dn, $data);
@@ -363,7 +381,7 @@ class CrudTest extends AbstractOnlineTestCase
     {
         $dn   = $this->createDn('ou=TestCreated,');
         $data = [
-            'objectClass' => ['organizationalUnit']
+            'objectClass' => ['organizationalUnit'],
         ];
         try {
             $this->getLdap()->add($dn, $data);
@@ -386,7 +404,7 @@ class CrudTest extends AbstractOnlineTestCase
         $dn   = $this->createDn('ou=TestCreated,');
         $data = [
             'ou'          => ['SecondOu'],
-            'objectClass' => ['organizationalUnit']
+            'objectClass' => ['organizationalUnit'],
         ];
         try {
             $this->getLdap()->add($dn, $data);
@@ -409,7 +427,7 @@ class CrudTest extends AbstractOnlineTestCase
         $dn   = $this->createDn('ou=TestCreated,');
         $data = [
             'ou'          => ['TestCreated', 'SecondOu'],
-            'objectClass' => ['organizationalUnit']
+            'objectClass' => ['organizationalUnit'],
         ];
         try {
             $this->getLdap()->add($dn, $data);
@@ -432,7 +450,7 @@ class CrudTest extends AbstractOnlineTestCase
         $dn   = $this->createDn('ou=TestCreated,');
         $data = [
             'ou'          => ['TestCreated'],
-            'objectClass' => ['organizationalUnit']
+            'objectClass' => ['organizationalUnit'],
         ];
         try {
             $this->getLdap()->add($dn, $data);
@@ -459,7 +477,7 @@ class CrudTest extends AbstractOnlineTestCase
         $dn   = $this->createDn('ou=TestCreated,');
         $data = [
             'ou'          => ['TestCreated'],
-            'objectClass' => ['organizationalUnit']
+            'objectClass' => ['organizationalUnit'],
         ];
         try {
             $this->getLdap()->add($dn, $data);

--- a/test/Dn/CreationTest.php
+++ b/test/Dn/CreationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Dn;
 
 use Laminas\Ldap;
@@ -19,26 +21,35 @@ class CreationTest extends TestCase
         $dnString1 = 'CN=Baker\\, Alice,CN=Users+OU=Lab,DC=example,DC=com';
         $dnArray1  = [
             ['CN' => 'Baker, Alice'],
-            ['CN' => 'Users',
-                  'OU' => 'Lab'],
+            [
+                'CN' => 'Users',
+                'OU' => 'Lab',
+            ],
             ['DC' => 'example'],
-            ['DC' => 'com']];
+            ['DC' => 'com'],
+        ];
 
         $dnString2 = 'cn=Baker\\, Alice,cn=Users+ou=Lab,dc=example,dc=com';
         $dnArray2  = [
             ['cn' => 'Baker, Alice'],
-            ['cn' => 'Users',
-                  'ou' => 'Lab'],
+            [
+                'cn' => 'Users',
+                'ou' => 'Lab',
+            ],
             ['dc' => 'example'],
-            ['dc' => 'com']];
+            ['dc' => 'com'],
+        ];
 
         $dnString3 = 'Cn=Baker\\, Alice,Cn=Users+Ou=Lab,Dc=example,Dc=com';
         $dnArray3  = [
             ['Cn' => 'Baker, Alice'],
-            ['Cn' => 'Users',
-                  'Ou' => 'Lab'],
+            [
+                'Cn' => 'Users',
+                'Ou' => 'Lab',
+            ],
             ['Dc' => 'example'],
-            ['Dc' => 'com']];
+            ['Dc' => 'com'],
+        ];
 
         $dn11 = Ldap\Dn::fromString($dnString1);
         $dn12 = Ldap\Dn::fromArray($dnArray1);
@@ -151,8 +162,10 @@ class CreationTest extends TestCase
 
         $dnString = 'Cn=Users+Ou=Lab,dc=example,dc=com';
         $dn       = Ldap\Dn::fromString($dnString);
-        $this->assertEquals(['Cn' => 'Users',
-                                 'Ou'  => 'Lab'], $dn->getRdn());
+        $this->assertEquals([
+            'Cn' => 'Users',
+            'Ou' => 'Lab',
+        ], $dn->getRdn());
         $this->assertEquals('Cn=Users+Ou=Lab', $dn->getRdnString());
     }
 

--- a/test/Dn/EscapingTest.php
+++ b/test/Dn/EscapingTest.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Dn;
 
 use Laminas\Ldap;
 use PHPUnit\Framework\TestCase;
+
+use function chr;
 
 /**
  * @group      Laminas_Ldap

--- a/test/Dn/ImplodingTest.php
+++ b/test/Dn/ImplodingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Dn;
 
 use Laminas\Ldap;
@@ -27,7 +29,7 @@ class ImplodingTest extends TestCase
             ["cn" => "name1"],
             ["cn" => "name2"],
             ["dc" => "example"],
-            ["dc" => "org"]
+            ["dc" => "org"],
         ];
         $dn       = Ldap\Dn::implodeDn($dnArray);
         $this->assertEquals($expected, $dn);
@@ -57,17 +59,21 @@ class ImplodingTest extends TestCase
 
     public function testImplodeRdnMultiValuedRdn()
     {
-        $a        = ['cn'  => 'value',
-                          'uid' => 'testUser'];
+        $a        = [
+            'cn'  => 'value',
+            'uid' => 'testUser',
+        ];
         $expected = 'cn=value+uid=testUser';
         $this->assertEquals($expected, Ldap\Dn::implodeRdn($a));
     }
 
     public function testImplodeRdnMultiValuedRdn2()
     {
-        $a        = ['cn'  => 'value',
-                          'uid' => 'testUser',
-                          'ou'  => 'myDep'];
+        $a        = [
+            'cn'  => 'value',
+            'uid' => 'testUser',
+            'ou'  => 'myDep',
+        ];
         $expected = 'cn=value+ou=myDep+uid=testUser';
         $this->assertEquals($expected, Ldap\Dn::implodeRdn($a));
     }
@@ -90,17 +96,21 @@ class ImplodingTest extends TestCase
 
     public function testImplodeRdnMultiValuedRdnCaseFold()
     {
-        $a        = ['cn'  => 'value',
-                          'uid' => 'testUser',
-                          'ou'  => 'myDep'];
+        $a        = [
+            'cn'  => 'value',
+            'uid' => 'testUser',
+            'ou'  => 'myDep',
+        ];
         $expected = 'CN=value+OU=myDep+UID=testUser';
         $this->assertEquals(
             $expected,
             Ldap\Dn::implodeRdn($a, Ldap\Dn::ATTR_CASEFOLD_UPPER)
         );
-        $a        = ['CN'  => 'value',
-                          'uID' => 'testUser',
-                          'ou'  => 'myDep'];
+        $a        = [
+            'CN'  => 'value',
+            'uID' => 'testUser',
+            'ou'  => 'myDep',
+        ];
         $expected = 'cn=value+ou=myDep+uid=testUser';
         $this->assertEquals(
             $expected,

--- a/test/Dn/MiscTest.php
+++ b/test/Dn/MiscTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Dn;
 
 use Laminas\Ldap;

--- a/test/Dn/ModificationTest.php
+++ b/test/Dn/ModificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Dn;
 
 use Laminas\Ldap;
@@ -18,8 +20,10 @@ class ModificationTest extends TestCase
         $dn       = Ldap\Dn::fromString($dnString);
 
         $this->assertEquals(['cn' => 'Baker, Alice'], $dn->get(0));
-        $this->assertEquals(['cn' => 'Users',
-                                 'ou'  => 'Lab'], $dn->get(1));
+        $this->assertEquals([
+            'cn' => 'Users',
+            'ou' => 'Lab',
+        ], $dn->get(1));
         $this->assertEquals(['dc' => 'example'], $dn->get(2));
         $this->assertEquals(['dc' => 'com'], $dn->get(3));
         try {
@@ -42,61 +46,75 @@ class ModificationTest extends TestCase
         }
 
         $this->assertEquals([
-                                 ['cn' => 'Baker, Alice'],
-                                 ['cn' => 'Users',
-                                       'ou' => 'Lab']
-                            ], $dn->get(0, 2));
+            ['cn' => 'Baker, Alice'],
+            [
+                'cn' => 'Users',
+                'ou' => 'Lab',
+            ],
+        ], $dn->get(0, 2));
         $this->assertEquals([
-                                 ['cn' => 'Baker, Alice'],
-                                 ['cn' => 'Users',
-                                       'ou' => 'Lab'],
-                                 ['dc' => 'example']
-                            ], $dn->get(0, 3));
+            ['cn' => 'Baker, Alice'],
+            [
+                'cn' => 'Users',
+                'ou' => 'Lab',
+            ],
+            ['dc' => 'example'],
+        ], $dn->get(0, 3));
         $this->assertEquals([
-                                 ['cn' => 'Baker, Alice'],
-                                 ['cn' => 'Users',
-                                       'ou' => 'Lab'],
-                                 ['dc' => 'example'],
-                                 ['dc' => 'com']
-                            ], $dn->get(0, 4));
+            ['cn' => 'Baker, Alice'],
+            [
+                'cn' => 'Users',
+                'ou' => 'Lab',
+            ],
+            ['dc' => 'example'],
+            ['dc' => 'com'],
+        ], $dn->get(0, 4));
         $this->assertEquals([
-                                 ['cn' => 'Baker, Alice'],
-                                 ['cn' => 'Users',
-                                       'ou' => 'Lab'],
-                                 ['dc' => 'example'],
-                                 ['dc' => 'com']
-                            ], $dn->get(0, 5));
+            ['cn' => 'Baker, Alice'],
+            [
+                'cn' => 'Users',
+                'ou' => 'Lab',
+            ],
+            ['dc' => 'example'],
+            ['dc' => 'com'],
+        ], $dn->get(0, 5));
 
         $this->assertEquals([
-                                 ['cn' => 'Users',
-                                       'ou' => 'Lab'],
-                                 ['dc' => 'example']
-                            ], $dn->get(1, 2));
+            [
+                'cn' => 'Users',
+                'ou' => 'Lab',
+            ],
+            ['dc' => 'example'],
+        ], $dn->get(1, 2));
         $this->assertEquals([
-                                 ['cn' => 'Users',
-                                       'ou' => 'Lab'],
-                                 ['dc' => 'example'],
-                                 ['dc' => 'com']
-                            ], $dn->get(1, 3));
+            [
+                'cn' => 'Users',
+                'ou' => 'Lab',
+            ],
+            ['dc' => 'example'],
+            ['dc' => 'com'],
+        ], $dn->get(1, 3));
         $this->assertEquals([
-                                 ['cn' => 'Users',
-                                       'ou' => 'Lab'],
-                                 ['dc' => 'example'],
-                                 ['dc' => 'com']
-                            ], $dn->get(1, 4));
+            [
+                'cn' => 'Users',
+                'ou' => 'Lab',
+            ],
+            ['dc' => 'example'],
+            ['dc' => 'com'],
+        ], $dn->get(1, 4));
 
         $this->assertEquals([
-                                 ['dc' => 'example'],
-                                 ['dc' => 'com']
-                            ], $dn->get(2, 2));
+            ['dc' => 'example'],
+            ['dc' => 'com'],
+        ], $dn->get(2, 2));
         $this->assertEquals([
-                                 ['dc' => 'example'],
-                                 ['dc' => 'com']
-                            ], $dn->get(2, 3));
+            ['dc' => 'example'],
+            ['dc' => 'com'],
+        ], $dn->get(2, 3));
 
         $this->assertEquals([
-                                 ['dc' => 'com']
-                            ], $dn->get(3, 2));
+            ['dc' => 'com'],
+        ], $dn->get(3, 2));
     }
 
     public function testDnManipulationSet()
@@ -114,8 +132,10 @@ class ModificationTest extends TestCase
         );
         $this->assertEquals(
             'uid=abaker,ou=Lab,dc=example+ou=Test,dc=com',
-            $dn->set(2, ['dc' => 'example',
-                             'ou'  => 'Test'])->toString()
+            $dn->set(2, [
+                'dc' => 'example',
+                'ou' => 'Test',
+            ])->toString()
         );
         $this->assertEquals(
             'uid=abaker,ou=Lab,dc=example+ou=Test,dc=de\+fr',
@@ -297,8 +317,10 @@ class ModificationTest extends TestCase
         $this->assertEquals('cn=Baker\\, Alice,ou=Lab,dc=example,dc=com', $dn->toString());
 
         $dn    = Ldap\Dn::fromString($dnString);
-        $dn[2] = ['dc' => 'example',
-                       'ou' => 'Test'];
+        $dn[2] = [
+            'dc' => 'example',
+            'ou' => 'Test',
+        ];
         $this->assertEquals('cn=Baker\\, Alice,cn=Users,dc=example+ou=Test,dc=com', $dn->toString());
 
         $dn    = Ldap\Dn::fromString($dnString);

--- a/test/ErrorHandler.php
+++ b/test/ErrorHandler.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
 use Laminas\Ldap\ErrorHandlerInterface;
 use Laminas\Stdlib\ErrorHandler as DefaultErrorHandler;
+
+use const E_WARNING;
 
 class ErrorHandler implements ErrorHandlerInterface
 {
@@ -11,7 +15,6 @@ class ErrorHandler implements ErrorHandlerInterface
      * Start the ErrorHandling-process
      *
      * @param int $level
-     *
      * @return void
      */
     public function startErrorHandling($level = E_WARNING)
@@ -25,7 +28,6 @@ class ErrorHandler implements ErrorHandlerInterface
      * be thrown as Exceptions or not
      *
      * @param bool|false $throw
-     *
      * @return mixed
      */
     public function stopErrorHandling($throw = false)

--- a/test/ErrorHandlerTest.php
+++ b/test/ErrorHandlerTest.php
@@ -1,23 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
+use Closure;
 use Laminas\Ldap\ErrorHandler;
 use PHPUnit\Framework\TestCase;
+
+use function restore_error_handler;
+use function set_error_handler;
 
 /**
  * @group      Laminas_Ldap
  */
 class ErrorHandlerTest extends TestCase
 {
+    /** @var callable */
     protected $dummyErrorHandler;
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->dummyErrorHandler = function ($errno, $error) {
         };
     }
-    public function testErrorHandlerSettingWorks()
+
+    public function testErrorHandlerSettingWorks(): void
     {
         $errorHandler = new ErrorHandler();
 
@@ -27,13 +37,13 @@ class ErrorHandlerTest extends TestCase
         $errorHandler->startErrorHandling();
         $returnValue2 = set_error_handler($this->dummyErrorHandler);
         $this->assertIsObject($returnValue2);
-        $this->assertInstanceOf(\Closure::class, $returnValue2);
+        $this->assertInstanceOf(Closure::class, $returnValue2);
 
         restore_error_handler();
         restore_error_handler();
     }
 
-    public function testErrorHandlerRemovalWorks()
+    public function testErrorHandlerRemovalWorks(): void
     {
         $errorHandler = new ErrorHandler();
 

--- a/test/Exception/LdapExceptionTest.php
+++ b/test/Exception/LdapExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Exception;
 
 use Laminas\Ldap\Exception\LdapException;
@@ -8,16 +10,8 @@ use PHPUnit\Framework\TestCase;
 
 class LdapExceptionTest extends TestCase
 {
-    /**
-     * @dataProvider constructorArgumentsProvider
-     *
-     * @param Ldap $ldap
-     * @param string $message
-     * @param int $code
-     * @param string $expectedMessage
-     * @param int $expectedCode
-     */
-    public function testException($ldap, $message, $code, $expectedMessage, $expectedCode)
+    /** @dataProvider constructorArgumentsProvider */
+    public function testException(?Ldap $ldap, string $message, int $code, string $expectedMessage, int $expectedCode)
     {
         $e = new LdapException($ldap, $message, $code);
 
@@ -25,11 +19,12 @@ class LdapExceptionTest extends TestCase
         $this->assertEquals($expectedCode, $e->getCode());
     }
 
-    public function constructorArgumentsProvider()
+    /** @return non-empty-array<string, array{null, '', int, non-empty-string, int}> */
+    public function constructorArgumentsProvider(): array
     {
         return [
             // Description => [LDAP object, message, code, expected message, expected code]
-            'default' => [null, '', 0, 'no exception message', 0],
+            'default'     => [null, '', 0, 'no exception message', 0],
             'hexadecimal' => [null, '', 15, '0xf: no exception message', 15],
         ];
     }

--- a/test/FilterTest.php
+++ b/test/FilterTest.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
 use Laminas\Ldap;
 use Laminas\Ldap\Filter;
 use Laminas\Ldap\Filter\Exception\FilterException;
 use PHPUnit\Framework\TestCase;
+
+use function chr;
 
 /**
  * @group      Laminas_Ldap
@@ -99,7 +103,7 @@ class FilterTest extends TestCase
     {
         $data = ['a', 'b', 5];
         $this->expectException(FilterException::class);
-        $f    = new Filter\AndFilter($data);
+        $f = new Filter\AndFilter($data);
     }
 
     public function testGroupingFilter()

--- a/test/Ldif/SimpleDecoderTest.php
+++ b/test/Ldif/SimpleDecoderTest.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Ldif;
 
 use Laminas\Ldap\Ldif;
 use LaminasTest\Ldap as TestLdap;
+
+use function array_merge;
 
 /**
  * @group      Laminas_Ldap
@@ -13,7 +17,7 @@ class SimpleDecoderTest extends TestLdap\AbstractTestCase
 {
     public function testDecodeSimpleSingleItem()
     {
-        $data =
+        $data     =
         "version: 1
 dn: cn=test3,ou=example,dc=cno
 objectclass: oc1
@@ -21,14 +25,15 @@ attr3: foo";
         $expected = [
             'dn'          => 'cn=test3,ou=example,dc=cno',
             'objectclass' => ['oc1'],
-            'attr3'       => ['foo']];
+            'attr3'       => ['foo'],
+        ];
         $actual   = Ldif\Encoder::decode($data);
         $this->assertEquals($expected, $actual);
     }
 
     public function testDecodeSingleItemWithFoldedAttribute()
     {
-        $data =
+        $data     =
         "dn: cn=test blabla,ou=example,dc=cno
 objectclass: oc2
 attr1: 12345
@@ -47,9 +52,11 @@ verylong: fhu08rhvt7b478vt5hv78h45nfgt45h78t34hhhhhhhhhv5bg8
             'attr2'       => ['1234', 'baz'],
             'attr3'       => ['foo', 'bar'],
             'cn'          => ['test blabla'],
-            'verylong'    => ['fhu08rhvt7b478vt5hv78h45nfgt45h78t34hhhhhhhhhv5bg8'
+            'verylong'    => [
+                'fhu08rhvt7b478vt5hv78h45nfgt45h78t34hhhhhhhhhv5bg8'
                                  . 'h6ttttttttt3489t57nhvgh4788trhg8999vnhtgthgui65hgb'
-                                 . '5789thvngwr789cghm738'],
+                                 . '5789thvngwr789cghm738',
+            ],
         ];
         $actual   = Ldif\Encoder::decode($data);
         $this->assertEquals($expected, $actual);
@@ -57,7 +64,7 @@ verylong: fhu08rhvt7b478vt5hv78h45nfgt45h78t34hhhhhhhhhv5bg8
 
     public function testDecodeSingleItemWithBase64Attributes()
     {
-        $data =
+        $data     =
         "dn:: Y249dGVzdCBibGFibGEsb3U9ZXhhbXBsZSxkYz1jbm8=
 objectclass: oc3
 attr1: 12345
@@ -87,7 +94,7 @@ cn:: dGVzdCDDtsOkw7w=";
 
     public function testDecodeSingleItemWithFoldedBase64Attribute()
     {
-        $data =
+        $data     =
         "dn:: Y249dGVzdCBibGFibGEsb
  3U9ZXhhbXBsZSxkYz1jbm8=
 objectclass: oc3
@@ -109,7 +116,7 @@ attr3: bar";
 
     public function testDecodeTwoItems()
     {
-        $data =
+        $data     =
         "version: 1
 dn: cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com
 objectclass: top
@@ -154,7 +161,7 @@ telephonenumber: +1 408 555 1212";
 
     public function testDecodeStringContainingEntryWithFoldedAttributeValue()
     {
-        $data =
+        $data     =
         "version: 1
 dn:cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com
 objectclass:top
@@ -170,15 +177,17 @@ description:Babs is a big sailing fan, and travels extensively in sea
  rch of perfect sailing conditions.
 title:Product Manager, Rod and Reel Division";
         $expected = [
-            'dn'                => 'cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com',
-            'objectclass'       => ['top', 'person', 'organizationalPerson'],
-            'cn'                => ['Barbara Jensen', 'Barbara J Jensen', 'Babs Jensen'],
-            'sn'                => ['Jensen'],
-            'uid'               => ['bjensen'],
-            'telephonenumber'   => ['+1 408 555 1212'],
-            'description'       => ['Babs is a big sailing fan, and travels extensively'
-                                       . ' in search of perfect sailing conditions.'],
-            'title'             => ['Product Manager, Rod and Reel Division'],
+            'dn'              => 'cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com',
+            'objectclass'     => ['top', 'person', 'organizationalPerson'],
+            'cn'              => ['Barbara Jensen', 'Barbara J Jensen', 'Babs Jensen'],
+            'sn'              => ['Jensen'],
+            'uid'             => ['bjensen'],
+            'telephonenumber' => ['+1 408 555 1212'],
+            'description'     => [
+                'Babs is a big sailing fan, and travels extensively'
+                                       . ' in search of perfect sailing conditions.',
+            ],
+            'title'           => ['Product Manager, Rod and Reel Division'],
         ];
         $actual   = Ldif\Encoder::decode($data);
         $this->assertEquals($expected, $actual);
@@ -186,7 +195,7 @@ title:Product Manager, Rod and Reel Division";
 
     public function testDecodeStringContainingBase64EncodedValue()
     {
-        $data =
+        $data     =
         "version: 1
 dn: cn=Gern Jensen, ou=Product Testing, dc=airius, dc=com
 objectclass: top
@@ -208,10 +217,12 @@ description:: V2hhdCBhIGNhcmVmdWwgcmVhZGVyIHlvdSBhcmUhICBUaGlzIHZhbHVl
             'sn'              => ['Jensen'],
             'uid'             => ['gernj'],
             'telephonenumber' => ['+1 408 555 1212'],
-            'description'     => ['What a careful reader you are!'
+            'description'     => [
+                'What a careful reader you are!'
                                      . '  This value is base-64-encoded because it has a '
                                      . 'control character in it (a CR).' . "\r"
-                                     . '  By the way, you should really get out more.'],
+                                     . '  By the way, you should really get out more.',
+            ],
         ];
         $actual   = Ldif\Encoder::decode($data);
         $this->assertEquals($expected, $actual);
@@ -313,7 +324,7 @@ title;lang-en: Sales, Director";
 
     public function testDecodeSingleItemWithFoldedAttributesAndEmptyLinesBetween()
     {
-        $data =
+        $data     =
         "dn: cn=test blabla,ou=example,dc=cno
 
 objectclass: top
@@ -340,13 +351,17 @@ verylong: fhu08rhvt7b478vt5hv78h45nfgt45h78t34hhhhhhhhhv5bg8
         $expected = [
             'dn'          => 'cn=test blabla,ou=example,dc=cno',
             'objectclass' => ['top', 'person', 'organizationalPerson'],
-            'description' => ['What a careful reader you are!'
+            'description' => [
+                'What a careful reader you are!'
                                  . '  This value is base-64-encoded because it has a '
                                  . 'control character in it (a CR).' . "\r"
-                                 . '  By the way, you should really get out more.'],
-            'verylong'    => ['fhu08rhvt7b478vt5hv78h45nfgt45h78t34hhhhhhhhhv5bg8'
+                                 . '  By the way, you should really get out more.',
+            ],
+            'verylong'    => [
+                'fhu08rhvt7b478vt5hv78h45nfgt45h78t34hhhhhhhhhv5bg8'
                                  . 'h6ttttttttt3489t57nhvgh4788trhg8999vnhtgthgui65hgb'
-                                 . '5789thvngwr789cghm738'],
+                                 . '5789thvngwr789cghm738',
+            ],
         ];
         $actual   = Ldif\Encoder::decode($data);
         $this->assertEquals($expected, $actual);
@@ -363,7 +378,7 @@ verylong: fhu08rhvt7b478vt5hv78h45nfgt45h78t34hhhhhhhhhv5bg8
 
     public function testDecodeSimpleSingleItemWithUri()
     {
-        $data =
+        $data     =
         "version: 1
 dn: cn=test3,ou=example,dc=cno
 objectclass: oc1
@@ -371,11 +386,11 @@ memberurl: ldap:///(&(cn=myName)(uid=something))";
         $expected = [
             'dn'          => 'cn=test3,ou=example,dc=cno',
             'objectclass' => ['oc1'],
-            'memberurl'   => ['ldap:///(&(cn=myName)(uid=something))']];
+            'memberurl'   => ['ldap:///(&(cn=myName)(uid=something))'],
+        ];
         $actual   = Ldif\Encoder::decode($data);
         $this->assertEquals($expected, $actual);
     }
-
 
     public function testDecodeSimpleSingleItemWithMultilineComment()
     {
@@ -394,7 +409,8 @@ attr3:: w7bDpMO8";
         $expected = [
             'dn'          => 'cn=test3,ou=example,dc=cno',
             'objectclass' => ['oc1'],
-            'attr3'       => ['öäü']];
+            'attr3'       => ['öäü'],
+        ];
         $actual   = Ldif\Encoder::decode($data);
         $this->assertEquals($expected, $actual[0]);
     }

--- a/test/Ldif/SimpleEncoderTest.php
+++ b/test/Ldif/SimpleEncoderTest.php
@@ -1,9 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Ldif;
 
 use Laminas\Ldap\Ldif;
 use LaminasTest\Ldap as TestLdap;
+use stdClass;
+
+use function base64_encode;
+
+use const PHP_EOL;
 
 /**
  * @group      Laminas_Ldap
@@ -11,13 +18,18 @@ use LaminasTest\Ldap as TestLdap;
  */
 class SimpleEncoderTest extends TestLdap\AbstractTestCase
 {
-    public static function stringEncodingProvider()
+    /** @return non-empty-list<array{string, string}> */
+    public static function stringEncodingProvider(): array
     {
-        $testData = [
-            ['cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com',
-                  'cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com'],
-            ['Babs is a big sailing fan, and travels extensively in search of perfect sailing conditions.',
-                  'Babs is a big sailing fan, and travels extensively in search of perfect sailing conditions.'],
+        return [
+            [
+                'cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com',
+                'cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com',
+            ],
+            [
+                'Babs is a big sailing fan, and travels extensively in search of perfect sailing conditions.',
+                'Babs is a big sailing fan, and travels extensively in search of perfect sailing conditions.',
+            ],
             ["\x00 NULL CHAR first", base64_encode("\x00 NULL CHAR first")],
             ["\n LF CHAR first", base64_encode("\n LF CHAR first")],
             ["\r CR CHAR first", base64_encode("\r CR CHAR first")],
@@ -31,50 +43,59 @@ class SimpleEncoderTest extends TestLdap\AbstractTestCase
             ["CHR(127) \x7f in string", base64_encode("CHR(127) \x7f in string")],
             ['Ä first', base64_encode('Ä first')],
             ['in Ä string', base64_encode('in Ä string')],
-            ['last char is a string ', base64_encode('last char is a string ')]
+            ['last char is a string ', base64_encode('last char is a string ')],
         ];
-        return $testData;
     }
 
     /**
      * @dataProvider stringEncodingProvider
      */
-    public function testStringEncoding($string, $expected)
+    public function testStringEncoding(string $string, string $expected): void
     {
         $this->assertEquals($expected, Ldif\Encoder::encode($string));
     }
 
-    public static function attributeEncodingProvider()
+    /** @return non-empty-list<array{array<string, mixed>, non-empty-string}> */
+    public static function attributeEncodingProvider(): array
     {
-        $testData = [
-            [['dn' => 'cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com'],
-                  'dn: cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com'],
-            [['dn' => 'cn=Jürgen Österreicher, ou=Äpfel, dc=airius, dc=com'],
-                  'dn:: ' . base64_encode('cn=Jürgen Österreicher, ou=Äpfel, dc=airius, dc=com')],
+        return [
+            [
+                ['dn' => 'cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com'],
+                'dn: cn=Barbara Jensen, ou=Product Development, dc=airius, dc=com',
+            ],
+            [
+                ['dn' => 'cn=Jürgen Österreicher, ou=Äpfel, dc=airius, dc=com'],
+                'dn:: ' . base64_encode('cn=Jürgen Österreicher, ou=Äpfel, dc=airius, dc=com'),
+            ],
             // @codingStandardsIgnoreStart
             [['description' => 'Babs is a big sailing fan, and travels extensively in search of perfect sailing conditions.'],
                 // @codingStandardsIgnoreEnd
-                  'description: Babs is a big sailing fan, and travels extensively in search of p'
-                      . PHP_EOL . ' erfect sailing conditions.'],
-            [['description' => "CHR(127) \x7f in string"],
-                  'description:: ' . base64_encode("CHR(127) \x7f in string")],
-            [['description' => '1234567890123456789012345678901234567890123456789012345678901234 567890'],
-                  'description: 1234567890123456789012345678901234567890123456789012345678901234 ' . PHP_EOL
-                      . ' 567890'],
+                'description: Babs is a big sailing fan, and travels extensively in search of p'
+                      . PHP_EOL . ' erfect sailing conditions.',
+            ],
+            [
+                ['description' => "CHR(127) \x7f in string"],
+                'description:: ' . base64_encode("CHR(127) \x7f in string"),
+            ],
+            [
+                ['description' => '1234567890123456789012345678901234567890123456789012345678901234 567890'],
+                'description: 1234567890123456789012345678901234567890123456789012345678901234 ' . PHP_EOL
+                      . ' 567890',
+            ],
         ];
-        return $testData;
     }
 
     /**
      * @dataProvider attributeEncodingProvider
+     * @param array<string, mixed> $array
      */
-    public function testAttributeEncoding($array, $expected)
+    public function testAttributeEncoding(array $array, string $expected): void
     {
         $actual = Ldif\Encoder::encode($array);
         $this->assertEquals($expected, $actual);
     }
 
-    public function testChangedWrapCount()
+    public function testChangedWrapCount(): void
     {
         $input    = '56789012345678901234567890';
         $expected = 'dn: 567890' . PHP_EOL . ' 1234567890' . PHP_EOL . ' 1234567890';
@@ -82,30 +103,31 @@ class SimpleEncoderTest extends TestLdap\AbstractTestCase
         $this->assertEquals($expected, $output);
     }
 
-    public function testEncodeMultipleAttributes()
+    public function testEncodeMultipleAttributes(): void
     {
         $data     = [
             'a' => ['a', 'b'],
             'b' => 'c',
             'c' => '',
             'd' => [],
-            'e' => ['']];
-        $expected = 'a: a' . PHP_EOL .
-            'a: b' . PHP_EOL .
-            'b: c' . PHP_EOL .
-            'c: ' . PHP_EOL .
-            'd: ' . PHP_EOL .
-            'e: ';
+            'e' => [''],
+        ];
+        $expected = 'a: a' . PHP_EOL
+            . 'a: b' . PHP_EOL
+            . 'b: c' . PHP_EOL
+            . 'c: ' . PHP_EOL
+            . 'd: ' . PHP_EOL
+            . 'e: ';
         $actual   = Ldif\Encoder::encode($data);
         $this->assertEquals($expected, $actual);
     }
 
-    public function testEncodeUnsupportedType()
+    public function testEncodeUnsupportedType(): void
     {
-        $this->assertNull(Ldif\Encoder::encode(new \stdClass()));
+        $this->assertNull(Ldif\Encoder::encode(new stdClass()));
     }
 
-    public function testSorting()
+    public function testSorting(): void
     {
         $data     = [
             'cn'          => ['name'],
@@ -115,49 +137,49 @@ class SimpleEncoderTest extends TestLdap\AbstractTestCase
             'boolean'     => ['TRUE', 'FALSE'],
             'objectclass' => ['account', 'top'],
         ];
-        $expected = 'version: 1' . PHP_EOL .
-            'dn: cn=name,dc=example,dc=org' . PHP_EOL .
-            'objectclass: account' . PHP_EOL .
-            'objectclass: top' . PHP_EOL .
-            'boolean: TRUE' . PHP_EOL .
-            'boolean: FALSE' . PHP_EOL .
-            'cn: name' . PHP_EOL .
-            'empty: ' . PHP_EOL .
-            'host: a' . PHP_EOL .
-            'host: b' . PHP_EOL .
-            'host: c';
+        $expected = 'version: 1' . PHP_EOL
+            . 'dn: cn=name,dc=example,dc=org' . PHP_EOL
+            . 'objectclass: account' . PHP_EOL
+            . 'objectclass: top' . PHP_EOL
+            . 'boolean: TRUE' . PHP_EOL
+            . 'boolean: FALSE' . PHP_EOL
+            . 'cn: name' . PHP_EOL
+            . 'empty: ' . PHP_EOL
+            . 'host: a' . PHP_EOL
+            . 'host: b' . PHP_EOL
+            . 'host: c';
         $actual   = Ldif\Encoder::encode($data);
         $this->assertEquals($expected, $actual);
 
-        $expected = 'version: 1' . PHP_EOL .
-            'cn: name' . PHP_EOL .
-            'dn: cn=name,dc=example,dc=org' . PHP_EOL .
-            'host: a' . PHP_EOL .
-            'host: b' . PHP_EOL .
-            'host: c' . PHP_EOL .
-            'empty: ' . PHP_EOL .
-            'boolean: TRUE' . PHP_EOL .
-            'boolean: FALSE' . PHP_EOL .
-            'objectclass: account' . PHP_EOL .
-            'objectclass: top';
+        $expected = 'version: 1' . PHP_EOL
+            . 'cn: name' . PHP_EOL
+            . 'dn: cn=name,dc=example,dc=org' . PHP_EOL
+            . 'host: a' . PHP_EOL
+            . 'host: b' . PHP_EOL
+            . 'host: c' . PHP_EOL
+            . 'empty: ' . PHP_EOL
+            . 'boolean: TRUE' . PHP_EOL
+            . 'boolean: FALSE' . PHP_EOL
+            . 'objectclass: account' . PHP_EOL
+            . 'objectclass: top';
         $actual   = Ldif\Encoder::encode($data, ['sort' => false]);
         $this->assertEquals($expected, $actual);
     }
 
-    public function testNodeEncoding()
+    public function testNodeEncoding(): void
     {
         $node     = $this->createTestNode();
-        $expected = 'version: 1' . PHP_EOL .
-            'dn: cn=name,dc=example,dc=org' . PHP_EOL .
-            'objectclass: account' . PHP_EOL .
-            'objectclass: top' . PHP_EOL .
-            'boolean: TRUE' . PHP_EOL .
-            'boolean: FALSE' . PHP_EOL .
-            'cn: name' . PHP_EOL .
-            'empty: ' . PHP_EOL .
-            'host: a' . PHP_EOL .
-            'host: b' . PHP_EOL .
-            'host: c';
+        $expected = 'version: 1' . PHP_EOL
+            . 'dn: cn=name,dc=example,dc=org' . PHP_EOL
+            . 'objectclass: account' . PHP_EOL
+            . 'objectclass: top' . PHP_EOL
+            . 'boolean: TRUE' . PHP_EOL
+            . 'boolean: FALSE' . PHP_EOL
+            . 'cn: name' . PHP_EOL
+            . 'empty: ' . PHP_EOL
+            . 'host: a' . PHP_EOL
+            . 'host: b' . PHP_EOL
+            . 'host: c';
         $actual   = $node->toLdif();
         $this->assertEquals($expected, $actual);
 
@@ -165,7 +187,7 @@ class SimpleEncoderTest extends TestLdap\AbstractTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testSupressVersionHeader()
+    public function testSupressVersionHeader(): void
     {
         $data     = [
             'cn'          => ['name'],
@@ -175,21 +197,21 @@ class SimpleEncoderTest extends TestLdap\AbstractTestCase
             'boolean'     => ['TRUE', 'FALSE'],
             'objectclass' => ['account', 'top'],
         ];
-        $expected = 'dn: cn=name,dc=example,dc=org' . PHP_EOL .
-            'objectclass: account' . PHP_EOL .
-            'objectclass: top' . PHP_EOL .
-            'boolean: TRUE' . PHP_EOL .
-            'boolean: FALSE' . PHP_EOL .
-            'cn: name' . PHP_EOL .
-            'empty: ' . PHP_EOL .
-            'host: a' . PHP_EOL .
-            'host: b' . PHP_EOL .
-            'host: c';
+        $expected = 'dn: cn=name,dc=example,dc=org' . PHP_EOL
+            . 'objectclass: account' . PHP_EOL
+            . 'objectclass: top' . PHP_EOL
+            . 'boolean: TRUE' . PHP_EOL
+            . 'boolean: FALSE' . PHP_EOL
+            . 'cn: name' . PHP_EOL
+            . 'empty: ' . PHP_EOL
+            . 'host: a' . PHP_EOL
+            . 'host: b' . PHP_EOL
+            . 'host: c';
         $actual   = Ldif\Encoder::encode($data, ['version' => null]);
         $this->assertEquals($expected, $actual);
     }
 
-    public function testEncodingWithJapaneseCharacters()
+    public function testEncodingWithJapaneseCharacters(): void
     {
         $data     = [
             'dn'                         => 'uid=rogasawara,ou=営業部,o=Airius',
@@ -214,32 +236,34 @@ class SimpleEncoderTest extends TestLdap\AbstractTestCase
             'cn;lang-en'                 => ['Rodney Ogasawara'],
             'title;lang-en'              => ['Sales, Director'],
         ];
-        $expected = 'dn:: dWlkPXJvZ2FzYXdhcmEsb3U95Za25qWt6YOoLG89QWlyaXVz' . PHP_EOL .
-            'objectclass: top' . PHP_EOL .
-            'objectclass: person' . PHP_EOL .
-            'objectclass: organizationalPerson' . PHP_EOL .
-            'objectclass: inetOrgPerson' . PHP_EOL .
-            'uid: rogasawara' . PHP_EOL .
-            'mail: rogasawara@airius.co.jp' . PHP_EOL .
-            'givenname;lang-ja:: 44Ot44OJ44OL44O8' . PHP_EOL .
-            'sn;lang-ja:: 5bCP56yg5Y6f' . PHP_EOL .
-            'cn;lang-ja:: 5bCP56yg5Y6fIOODreODieODi+ODvA==' . PHP_EOL .
-            'title;lang-ja:: 5Za25qWt6YOoIOmDqOmVtw==' . PHP_EOL .
-            'preferredlanguage: ja' . PHP_EOL .
-            'givenname:: 44Ot44OJ44OL44O8' . PHP_EOL .
-            'sn:: 5bCP56yg5Y6f' . PHP_EOL .
-            'cn:: 5bCP56yg5Y6fIOODreODieODi+ODvA==' . PHP_EOL .
-            'title:: 5Za25qWt6YOoIOmDqOmVtw==' . PHP_EOL .
-            'givenname;lang-ja;phonetic:: 44KN44Gp44Gr44O8' . PHP_EOL .
-            'sn;lang-ja;phonetic:: 44GK44GM44GV44KP44KJ' . PHP_EOL .
-            'cn;lang-ja;phonetic:: 44GK44GM44GV44KP44KJIOOCjeOBqeOBq+ODvA==' . PHP_EOL .
-            'title;lang-ja;phonetic:: 44GI44GE44GO44KH44GG44G2IOOBtuOBoeOCh+OBhg==' . PHP_EOL .
-            'givenname;lang-en: Rodney' . PHP_EOL .
-            'sn;lang-en: Ogasawara' . PHP_EOL .
-            'cn;lang-en: Rodney Ogasawara' . PHP_EOL .
-            'title;lang-en: Sales, Director';
-        $actual   = Ldif\Encoder::encode($data, ['sort'   => false,
-                                                     'version' => null]);
+        $expected = 'dn:: dWlkPXJvZ2FzYXdhcmEsb3U95Za25qWt6YOoLG89QWlyaXVz' . PHP_EOL
+            . 'objectclass: top' . PHP_EOL
+            . 'objectclass: person' . PHP_EOL
+            . 'objectclass: organizationalPerson' . PHP_EOL
+            . 'objectclass: inetOrgPerson' . PHP_EOL
+            . 'uid: rogasawara' . PHP_EOL
+            . 'mail: rogasawara@airius.co.jp' . PHP_EOL
+            . 'givenname;lang-ja:: 44Ot44OJ44OL44O8' . PHP_EOL
+            . 'sn;lang-ja:: 5bCP56yg5Y6f' . PHP_EOL
+            . 'cn;lang-ja:: 5bCP56yg5Y6fIOODreODieODi+ODvA==' . PHP_EOL
+            . 'title;lang-ja:: 5Za25qWt6YOoIOmDqOmVtw==' . PHP_EOL
+            . 'preferredlanguage: ja' . PHP_EOL
+            . 'givenname:: 44Ot44OJ44OL44O8' . PHP_EOL
+            . 'sn:: 5bCP56yg5Y6f' . PHP_EOL
+            . 'cn:: 5bCP56yg5Y6fIOODreODieODi+ODvA==' . PHP_EOL
+            . 'title:: 5Za25qWt6YOoIOmDqOmVtw==' . PHP_EOL
+            . 'givenname;lang-ja;phonetic:: 44KN44Gp44Gr44O8' . PHP_EOL
+            . 'sn;lang-ja;phonetic:: 44GK44GM44GV44KP44KJ' . PHP_EOL
+            . 'cn;lang-ja;phonetic:: 44GK44GM44GV44KP44KJIOOCjeOBqeOBq+ODvA==' . PHP_EOL
+            . 'title;lang-ja;phonetic:: 44GI44GE44GO44KH44GG44G2IOOBtuOBoeOCh+OBhg==' . PHP_EOL
+            . 'givenname;lang-en: Rodney' . PHP_EOL
+            . 'sn;lang-en: Ogasawara' . PHP_EOL
+            . 'cn;lang-en: Rodney Ogasawara' . PHP_EOL
+            . 'title;lang-en: Sales, Director';
+        $actual   = Ldif\Encoder::encode($data, [
+            'sort'    => false,
+            'version' => null,
+        ]);
         $this->assertEquals($expected, $actual);
     }
 }

--- a/test/Node/AttributeIterationTest.php
+++ b/test/Node/AttributeIterationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Node;
 
 use LaminasTest\Ldap as TestLdap;
@@ -25,10 +27,11 @@ class AttributeIterationTest extends TestLdap\AbstractTestCase
         $this->assertEquals(5, $i);
         $this->assertCount($i, $node);
         $this->assertEquals([
-                                 'boolean'     => [true, false],
-                                 'cn'          => ['name'],
-                                 'empty'       => [],
-                                 'host'        => ['a', 'b', 'c'],
-                                 'objectclass' => ['account', 'top']], $data);
+            'boolean'     => [true, false],
+            'cn'          => ['name'],
+            'empty'       => [],
+            'host'        => ['a', 'b', 'c'],
+            'objectclass' => ['account', 'top'],
+        ], $data);
     }
 }

--- a/test/Node/ChildrenIterationTest.php
+++ b/test/Node/ChildrenIterationTest.php
@@ -1,9 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Node;
 
 use Laminas\Ldap;
+use Laminas\Ldap\Node;
 use LaminasTest\Ldap as TestLdap;
+use RecursiveIteratorIterator;
+
+use function getenv;
 
 /**
  * @group      Laminas_Ldap
@@ -32,7 +38,7 @@ class ChildrenIterationTest extends TestLdap\AbstractOnlineTestCase
         foreach ($children as $rdn => $n) {
             $dn  = $n->getDn()->toString(Ldap\Dn::ATTR_CASEFOLD_LOWER);
             $rdn = Ldap\Dn::implodeRdn($n->getRdnArray(), Ldap\Dn::ATTR_CASEFOLD_LOWER);
-            if ($i == 1) {
+            if ($i === 1) {
                 $this->assertEquals('ou=Node', $rdn);
                 $this->assertEquals($this->createDn('ou=Node,'), $dn);
             } else {
@@ -47,15 +53,15 @@ class ChildrenIterationTest extends TestLdap\AbstractOnlineTestCase
     public function testSimpleRecursiveIteration()
     {
         $node = $this->getLDAP()->getBaseNode();
-        $ri   = new \RecursiveIteratorIterator($node, \RecursiveIteratorIterator::SELF_FIRST);
+        $ri   = new RecursiveIteratorIterator($node, RecursiveIteratorIterator::SELF_FIRST);
         $i    = 0;
         foreach ($ri as $rdn => $n) {
             $dn  = $n->getDn()->toString(Ldap\Dn::ATTR_CASEFOLD_LOWER);
             $rdn = Ldap\Dn::implodeRdn($n->getRdnArray(), Ldap\Dn::ATTR_CASEFOLD_LOWER);
-            if ($i == 0) {
+            if ($i === 0) {
                 $this->assertEquals(Ldap\Dn::fromString(getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'))
                         ->toString(Ldap\Dn::ATTR_CASEFOLD_LOWER), $dn);
-            } elseif ($i == 1) {
+            } elseif ($i === 1) {
                 $this->assertEquals('ou=Node', $rdn);
                 $this->assertEquals($this->createDn('ou=Node,'), $dn);
             } else {
@@ -84,10 +90,10 @@ class ChildrenIterationTest extends TestLdap\AbstractOnlineTestCase
     {
         $node  = $this->getLDAP()->getBaseNode();
         $nodes = $node->searchChildren('(objectClass=*)');
-        foreach ($nodes as $rdn => $n) {
+        foreach ($nodes as $rdn => $n) { // phpcs:ignore
             // do nothing - just iterate
         }
         $nodes->next();
-        $this->assertInstanceOf(\Laminas\Ldap\Node::class, $nodes->current());
+        $this->assertInstanceOf(Node::class, $nodes->current());
     }
 }

--- a/test/Node/ChildrenTest.php
+++ b/test/Node/ChildrenTest.php
@@ -1,8 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Node;
 
+use Laminas\Ldap\Node;
+use Laminas\Ldap\Node\ChildrenIterator;
 use LaminasTest\Ldap as TestLdap;
+
+use function getenv;
+use function serialize;
+use function unserialize;
 
 /**
  * @group      Laminas_Ldap
@@ -26,9 +34,9 @@ class ChildrenTest extends TestLdap\AbstractOnlineTestCase
     {
         $node     = $this->getLDAP()->getBaseNode();
         $children = $node->getChildren();
-        $this->assertInstanceOf('Laminas\Ldap\Node\ChildrenIterator', $children);
+        $this->assertInstanceOf(ChildrenIterator::class, $children);
         $this->assertCount(6, $children);
-        $this->assertInstanceOf('Laminas\Ldap\Node', $children['ou=Node']);
+        $this->assertInstanceOf(Node::class, $children['ou=Node']);
     }
 
     public function testGetChildrenOnDetachedNode()
@@ -36,16 +44,16 @@ class ChildrenTest extends TestLdap\AbstractOnlineTestCase
         $node = $this->getLDAP()->getBaseNode();
         $node->detachLDAP();
         $children = $node->getChildren();
-        $this->assertInstanceOf('Laminas\Ldap\Node\ChildrenIterator', $children);
+        $this->assertInstanceOf(ChildrenIterator::class, $children);
         $this->assertCount(0, $children);
 
         $node->attachLDAP($this->getLDAP());
         $node->reload();
         $children = $node->getChildren();
 
-        $this->assertInstanceOf('Laminas\Ldap\Node\ChildrenIterator', $children);
+        $this->assertInstanceOf(ChildrenIterator::class, $children);
         $this->assertCount(6, $children);
-        $this->assertInstanceOf('Laminas\Ldap\Node', $children['ou=Node']);
+        $this->assertInstanceOf(Node::class, $children['ou=Node']);
     }
 
     public function testHasChildrenOnAttachedNode()

--- a/test/Node/OnlineTest.php
+++ b/test/Node/OnlineTest.php
@@ -1,11 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Node;
 
 use Laminas\Ldap;
-use Laminas\Ldap\Exception;
 use Laminas\Ldap\Exception\ExceptionInterface;
+use Laminas\Ldap\Node;
+use Laminas\Ldap\Node\Collection;
 use LaminasTest\Ldap as TestLdap;
+
+use function getenv;
+use function key;
+use function serialize;
+use function unserialize;
 
 /**
  * @group      Laminas_Ldap
@@ -29,7 +37,7 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
     {
         $dn   = $this->createDn('ou=Test1,');
         $node = Ldap\Node::fromLDAP($dn, $this->getLDAP());
-        $this->assertInstanceOf('Laminas\Ldap\Node', $node);
+        $this->assertInstanceOf(Node::class, $node);
         $this->assertTrue($node->isAttached());
     }
 
@@ -72,7 +80,7 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
 
     public function testLoadFromLDAPIllegalEntry()
     {
-        $dn   = $this->createDn('ou=Test99,');
+        $dn = $this->createDn('ou=Test99,');
         $this->expectException(ExceptionInterface::class);
         $node = Ldap\Node::fromLDAP($dn, $this->getLDAP());
     }
@@ -81,7 +89,7 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
     {
         $dn   = $this->createDn('ou=Test1,');
         $node = Ldap\Node::fromLDAP($dn, $this->getLDAP());
-        $this->assertInstanceOf('Laminas\Ldap\Node', $node);
+        $this->assertInstanceOf(Node::class, $node);
         $this->assertTrue($node->isAttached());
         $node->detachLDAP();
         $this->assertFalse($node->isAttached());
@@ -163,7 +171,7 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
 
     public function testGetIllegalNode()
     {
-        $dn   = $this->createDn('ou=Test99,');
+        $dn = $this->createDn('ou=Test99,');
         $this->expectException(ExceptionInterface::class);
         $node = $this->getLDAP()->getNode($dn);
     }
@@ -189,14 +197,15 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
             [],
             'ou'
         );
-        $this->assertInstanceOf('Laminas\Ldap\Node\Collection', $items);
+        $this->assertInstanceOf(Collection::class, $items);
         $this->assertEquals(3, $items->count());
 
         $i   = 0;
         $dns = [
             $this->createDn('ou=Node,'),
             $this->createDn('ou=Test1,ou=Node,'),
-            $this->createDn('ou=Test2,ou=Node,')];
+            $this->createDn('ou=Test2,ou=Node,'),
+        ];
         foreach ($items as $key => $node) {
             $key = Ldap\Dn::fromString($key)->toString(Ldap\Dn::ATTR_CASEFOLD_LOWER);
             $this->assertEquals($dns[$i], $key);
@@ -249,7 +258,7 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
 
     public function testGetNonexistentParent()
     {
-        $node  = $this->getLDAP()->getNode(getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'));
+        $node = $this->getLDAP()->getNode(getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'));
         $this->expectException(ExceptionInterface::class);
         $pnode = $node->getParent();
     }
@@ -258,7 +267,7 @@ class OnlineTest extends TestLdap\AbstractOnlineTestCase
     {
         $dn   = Ldap\Dn::fromString($this->createDn('ou=Test1,'));
         $node = Ldap\Node::fromLDAP($dn, $this->getLDAP());
-        $this->assertInstanceOf('Laminas\Ldap\Node', $node);
+        $this->assertInstanceOf(Node::class, $node);
         $this->assertTrue($node->isAttached());
     }
 }

--- a/test/Node/RootDseTest.php
+++ b/test/Node/RootDseTest.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Node;
 
+use BadMethodCallException;
 use Laminas\Ldap\Node;
 use LaminasTest\Ldap as TestLdap;
 
@@ -34,29 +37,41 @@ class RootDseTest extends TestLdap\AbstractOnlineTestCase
         switch ($root->getServerType()) {
             case Node\RootDse::SERVER_TYPE_ACTIVEDIRECTORY:
                 $this->assertIsBool($root->supportsControl('1.2.840.113556.1.4.319'));
-                $this->assertIsBool($root->supportsControl(['1.2.840.113556.1.4.319',
-                                                                                 '1.2.840.113556.1.4.473']));
+                $this->assertIsBool($root->supportsControl([
+                    '1.2.840.113556.1.4.319',
+                    '1.2.840.113556.1.4.473',
+                ]));
                 $this->assertIsBool($root->supportsCapability('1.3.6.1.4.1.4203.1.9.1.1'));
-                $this->assertIsBool($root->supportsCapability(['1.3.6.1.4.1.4203.1.9.1.1',
-                                                                                    '2.16.840.1.113730.3.4.18']));
+                $this->assertIsBool($root->supportsCapability([
+                    '1.3.6.1.4.1.4203.1.9.1.1',
+                    '2.16.840.1.113730.3.4.18',
+                ]));
                 $this->assertIsBool($root->supportsPolicy('unknown'));
                 $this->assertIsBool($root->supportsPolicy(['unknown', 'unknown']));
                 break;
             case Node\RootDse::SERVER_TYPE_EDIRECTORY:
                 $this->assertIsBool($root->supportsExtension('1.3.6.1.4.1.1466.20037'));
-                $this->assertIsBool($root->supportsExtension(['1.3.6.1.4.1.1466.20037',
-                                                                                   '1.3.6.1.4.1.4203.1.11.1']));
+                $this->assertIsBool($root->supportsExtension([
+                    '1.3.6.1.4.1.1466.20037',
+                    '1.3.6.1.4.1.4203.1.11.1',
+                ]));
                 break;
             case Node\RootDse::SERVER_TYPE_OPENLDAP:
                 $this->assertIsBool($root->supportsControl('1.3.6.1.4.1.4203.1.9.1.1'));
-                $this->assertIsBool($root->supportsControl(['1.3.6.1.4.1.4203.1.9.1.1',
-                                                                                 '2.16.840.1.113730.3.4.18']));
+                $this->assertIsBool($root->supportsControl([
+                    '1.3.6.1.4.1.4203.1.9.1.1',
+                    '2.16.840.1.113730.3.4.18',
+                ]));
                 $this->assertIsBool($root->supportsExtension('1.3.6.1.4.1.1466.20037'));
-                $this->assertIsBool($root->supportsExtension(['1.3.6.1.4.1.1466.20037',
-                                                                                   '1.3.6.1.4.1.4203.1.11.1']));
+                $this->assertIsBool($root->supportsExtension([
+                    '1.3.6.1.4.1.1466.20037',
+                    '1.3.6.1.4.1.4203.1.11.1',
+                ]));
                 $this->assertIsBool($root->supportsFeature('1.3.6.1.1.14'));
-                $this->assertIsBool($root->supportsFeature(['1.3.6.1.1.14',
-                                                                                 '1.3.6.1.4.1.4203.1.5.1']));
+                $this->assertIsBool($root->supportsFeature([
+                    '1.3.6.1.1.14',
+                    '1.3.6.1.4.1.4203.1.5.1',
+                ]));
                 break;
         }
     }
@@ -105,7 +120,8 @@ class RootDseTest extends TestLdap\AbstractOnlineTestCase
         }
     }
 
-    protected function assertNullOrString($value)
+    /** @param mixed $value */
+    protected function assertNullOrString($value): void
     {
         if ($value === null) {
             $this->assertNull($value);
@@ -116,29 +132,29 @@ class RootDseTest extends TestLdap\AbstractOnlineTestCase
 
     public function testSetterWillThrowException()
     {
-        $root              = $this->getLDAP()->getRootDse();
-        $this->expectException(\BadMethodCallException::class);
+        $root = $this->getLDAP()->getRootDse();
+        $this->expectException(BadMethodCallException::class);
         $root->objectClass = 'illegal';
     }
 
     public function testOffsetSetWillThrowException()
     {
-        $root                = $this->getLDAP()->getRootDse();
-        $this->expectException(\BadMethodCallException::class);
+        $root = $this->getLDAP()->getRootDse();
+        $this->expectException(BadMethodCallException::class);
         $root['objectClass'] = 'illegal';
     }
 
     public function testUnsetterWillThrowException()
     {
         $root = $this->getLDAP()->getRootDse();
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         unset($root->objectClass);
     }
 
     public function testOffsetUnsetWillThrowException()
     {
         $root = $this->getLDAP()->getRootDse();
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         unset($root['objectClass']);
     }
 }

--- a/test/Node/SchemaTest.php
+++ b/test/Node/SchemaTest.php
@@ -1,9 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Node;
 
+use BadMethodCallException;
 use Laminas\Ldap\Node;
+use Laminas\Ldap\Node\Schema;
+use Laminas\Ldap\Node\Schema\ObjectClass\OpenLdap;
 use LaminasTest\Ldap as TestLdap;
+
+use function array_key_exists;
+use function serialize;
+use function unserialize;
 
 /**
  * @group      Laminas_Ldap
@@ -11,9 +20,7 @@ use LaminasTest\Ldap as TestLdap;
  */
 class SchemaTest extends TestLdap\AbstractOnlineTestCase
 {
-    /**
-     * @var Node\Schema
-     */
+    /** @var Node\Schema */
     private $schema;
 
     protected function setUp(): void
@@ -55,31 +62,32 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
 
     public function testSetterWillThrowException()
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->schema->objectClass = 'illegal';
     }
 
     public function testOffsetSetWillThrowException()
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->schema['objectClass'] = 'illegal';
     }
 
     public function testUnsetterWillThrowException()
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         unset($this->schema->objectClass);
     }
 
     public function testOffsetUnsetWillThrowException()
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         unset($this->schema['objectClass']);
     }
 
     public function testOpenLDAPSchema()
     {
-        if ($this->getLDAP()->getRootDse()->getServerType() !==
+        if (
+            $this->getLDAP()->getRootDse()->getServerType() !==
             Node\RootDse::SERVER_TYPE_OPENLDAP
         ) {
             $this->markTestSkipped('Test can only be run on an OpenLDAP server');
@@ -90,18 +98,35 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
 
         $this->assertArrayHasKey('organizationalUnit', $objectClasses);
         $ou = $objectClasses['organizationalUnit'];
-        $this->assertInstanceOf('Laminas\Ldap\Node\Schema\ObjectClass\OpenLdap', $ou);
+        $this->assertInstanceOf(OpenLdap::class, $ou);
         $this->assertEquals('organizationalUnit', $ou->getName());
         $this->assertEquals('2.5.6.5', $ou->getOid());
         $this->assertEquals(['objectClass', 'ou'], $ou->getMustContain());
-        $this->assertEquals(['businessCategory', 'description', 'destinationIndicator',
-                                 'facsimileTelephoneNumber', 'internationaliSDNNumber', 'l',
-                                 'physicalDeliveryOfficeName', 'postOfficeBox', 'postalAddress', 'postalCode',
-                                 'preferredDeliveryMethod', 'registeredAddress', 'searchGuide', 'seeAlso', 'st',
-                                 'street', 'telephoneNumber', 'teletexTerminalIdentifier', 'telexNumber',
-                                 'userPassword', 'x121Address'], $ou->getMayContain());
+        $this->assertEquals([
+            'businessCategory',
+            'description',
+            'destinationIndicator',
+            'facsimileTelephoneNumber',
+            'internationaliSDNNumber',
+            'l',
+            'physicalDeliveryOfficeName',
+            'postOfficeBox',
+            'postalAddress',
+            'postalCode',
+            'preferredDeliveryMethod',
+            'registeredAddress',
+            'searchGuide',
+            'seeAlso',
+            'st',
+            'street',
+            'telephoneNumber',
+            'teletexTerminalIdentifier',
+            'telexNumber',
+            'userPassword',
+            'x121Address',
+        ], $ou->getMayContain());
         $this->assertEquals('RFC2256: an organizational unit', $ou->getDescription());
-        $this->assertEquals(\Laminas\Ldap\Node\Schema::OBJECTCLASS_TYPE_STRUCTURAL, $ou->getType());
+        $this->assertEquals(Schema::OBJECTCLASS_TYPE_STRUCTURAL, $ou->getType());
         $this->assertEquals(['top'], $ou->getParentClasses());
 
         $this->assertEquals('2.5.6.5', $ou->oid);
@@ -113,26 +138,43 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
         $this->assertTrue($ou->structural);
         $this->assertFalse($ou->auxiliary);
         $this->assertEquals(['ou'], $ou->must);
-        $this->assertEquals(['userPassword', 'searchGuide', 'seeAlso', 'businessCategory',
-                                 'x121Address', 'registeredAddress', 'destinationIndicator', 'preferredDeliveryMethod',
-                                 'telexNumber', 'teletexTerminalIdentifier', 'telephoneNumber',
-                                 'internationaliSDNNumber', 'facsimileTelephoneNumber', 'street', 'postOfficeBox',
-                                 'postalCode', 'postalAddress', 'physicalDeliveryOfficeName', 'st', 'l',
-                                 'description'], $ou->may);
-        $this->assertEquals("( 2.5.6.5 NAME 'organizationalUnit' " .
-                "DESC 'RFC2256: an organizational unit' SUP top STRUCTURAL MUST ou " .
-                "MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $ x121Address $ " .
-                "registeredAddress $ destinationIndicator $ preferredDeliveryMethod $ telexNumber $ " .
-                "teletexTerminalIdentifier $ telephoneNumber $ internationaliSDNNumber $ " .
-                "facsimileTelephoneNumber $ street $ postOfficeBox $ postalCode $ postalAddress $ " .
-                "physicalDeliveryOfficeName $ st $ l $ description ) )", $ou->_string);
+        $this->assertEquals([
+            'userPassword',
+            'searchGuide',
+            'seeAlso',
+            'businessCategory',
+            'x121Address',
+            'registeredAddress',
+            'destinationIndicator',
+            'preferredDeliveryMethod',
+            'telexNumber',
+            'teletexTerminalIdentifier',
+            'telephoneNumber',
+            'internationaliSDNNumber',
+            'facsimileTelephoneNumber',
+            'street',
+            'postOfficeBox',
+            'postalCode',
+            'postalAddress',
+            'physicalDeliveryOfficeName',
+            'st',
+            'l',
+            'description',
+        ], $ou->may);
+        $this->assertEquals("( 2.5.6.5 NAME 'organizationalUnit' "
+                . "DESC 'RFC2256: an organizational unit' SUP top STRUCTURAL MUST ou "
+                . "MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $ x121Address $ "
+                . "registeredAddress $ destinationIndicator $ preferredDeliveryMethod $ telexNumber $ "
+                . "teletexTerminalIdentifier $ telephoneNumber $ internationaliSDNNumber $ "
+                . "facsimileTelephoneNumber $ street $ postOfficeBox $ postalCode $ postalAddress $ "
+                . "physicalDeliveryOfficeName $ st $ l $ description ) )", $ou->_string);
 
         $this->assertEquals([], $ou->aliases);
         $this->assertSame($objectClasses['top'], $ou->_parents[0]);
 
         $this->assertArrayHasKey('ou', $attributeTypes);
         $ou = $attributeTypes['ou'];
-        $this->assertInstanceOf('Laminas\Ldap\Node\Schema\AttributeType\OpenLdap', $ou);
+        $this->assertInstanceOf(\Laminas\Ldap\Node\Schema\AttributeType\OpenLdap::class, $ou);
         $this->assertEquals('ou', $ou->getName());
         $this->assertEquals('2.5.4.11', $ou->getOid());
         $this->assertEquals('1.3.6.1.4.1.1466.115.121.1.15', $ou->getSyntax());
@@ -154,15 +196,16 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
         $this->assertFalse($ou->collective);
         $this->assertFalse($ou->{'no-user-modification'});
         $this->assertEquals('userApplications', $ou->usage);
-        $this->assertEquals("( 2.5.4.11 NAME ( 'ou' 'organizationalUnitName' ) " .
-                "DESC 'RFC2256: organizational unit this object belongs to' SUP name )", $ou->_string);
+        $this->assertEquals("( 2.5.4.11 NAME ( 'ou' 'organizationalUnitName' ) "
+                . "DESC 'RFC2256: organizational unit this object belongs to' SUP name )", $ou->_string);
         $this->assertEquals(['organizationalUnitName'], $ou->aliases);
         $this->assertSame($attributeTypes['name'], $ou->_parents[0]);
     }
 
     public function testActiveDirectorySchema()
     {
-        if ($this->getLDAP()->getRootDse()->getServerType() !==
+        if (
+            $this->getLDAP()->getRootDse()->getServerType() !==
             Node\RootDse::SERVER_TYPE_ACTIVEDIRECTORY
         ) {
             $this->markTestSkipped('Test can only be run on an Active Directory server');
@@ -174,7 +217,8 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
 
     public function testeDirectorySchema()
     {
-        if ($this->getLDAP()->getRootDse()->getServerType() !==
+        if (
+            $this->getLDAP()->getRootDse()->getServerType() !==
             Node\RootDse::SERVER_TYPE_EDIRECTORY
         ) {
             $this->markTestSkipped('Test can only be run on an eDirectory server');
@@ -184,7 +228,8 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
 
     public function testOpenLDAPSchemaAttributeTypeInheritance()
     {
-        if ($this->getLDAP()->getRootDse()->getServerType() !==
+        if (
+            $this->getLDAP()->getRootDse()->getServerType() !==
             Node\RootDse::SERVER_TYPE_OPENLDAP
         ) {
             $this->markTestSkipped('Test can only be run on an OpenLDAP server');
@@ -219,7 +264,8 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
 
     public function testOpenLDAPSchemaObjectClassInheritance()
     {
-        if ($this->getLDAP()->getRootDse()->getServerType() !==
+        if (
+            $this->getLDAP()->getRootDse()->getServerType() !==
             Node\RootDse::SERVER_TYPE_OPENLDAP
         ) {
             $this->markTestSkipped('Test can only be run on an OpenLDAP server');
@@ -227,7 +273,8 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
 
         $objectClasses = $this->schema->getObjectClasses();
 
-        if (! array_key_exists('certificationAuthority', $objectClasses)
+        if (
+            ! array_key_exists('certificationAuthority', $objectClasses)
             || ! array_key_exists('certificationAuthority-V2', $objectClasses)
         ) {
             $this->markTestSkipped('This requires OpenLDAP core schema');
@@ -241,16 +288,27 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
         $this->assertEquals(['top'], $ca->sup);
         $this->assertEquals(['certificationAuthority'], $ca2->sup);
 
-        $this->assertEquals(['authorityRevocationList', 'certificateRevocationList',
-                                 'cACertificate'], $ca->must);
-        $this->assertEquals(['authorityRevocationList', 'cACertificate',
-                                 'certificateRevocationList', 'objectClass'], $ca->getMustContain());
+        $this->assertEquals([
+            'authorityRevocationList',
+            'certificateRevocationList',
+            'cACertificate',
+        ], $ca->must);
+        $this->assertEquals([
+            'authorityRevocationList',
+            'cACertificate',
+            'certificateRevocationList',
+            'objectClass',
+        ], $ca->getMustContain());
         $this->assertEquals(['crossCertificatePair'], $ca->may);
         $this->assertEquals(['crossCertificatePair'], $ca->getMayContain());
 
         $this->assertEquals([], $ca2->must);
-        $this->assertEquals(['authorityRevocationList', 'cACertificate',
-                                 'certificateRevocationList', 'objectClass'], $ca2->getMustContain());
+        $this->assertEquals([
+            'authorityRevocationList',
+            'cACertificate',
+            'certificateRevocationList',
+            'objectClass',
+        ], $ca2->getMustContain());
         $this->assertEquals(['deltaRevocationList'], $ca2->may);
         $this->assertEquals(
             ['crossCertificatePair', 'deltaRevocationList'],
@@ -260,7 +318,8 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
 
     public function testOpenLDAPSchemaAttributeTypeAliases()
     {
-        if ($this->getLDAP()->getRootDse()->getServerType() !==
+        if (
+            $this->getLDAP()->getRootDse()->getServerType() !==
             Node\RootDse::SERVER_TYPE_OPENLDAP
         ) {
             $this->markTestSkipped('Test can only be run on an OpenLDAP server');
@@ -276,7 +335,8 @@ class SchemaTest extends TestLdap\AbstractOnlineTestCase
 
     public function testOpenLDAPSchemaObjectClassAliases()
     {
-        if ($this->getLDAP()->getRootDse()->getServerType() !==
+        if (
+            $this->getLDAP()->getRootDse()->getServerType() !==
             Node\RootDse::SERVER_TYPE_OPENLDAP
         ) {
             $this->markTestSkipped('Test can only be run on an OpenLDAP server');

--- a/test/Node/UpdateTest.php
+++ b/test/Node/UpdateTest.php
@@ -1,9 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\Node;
 
 use Laminas\Ldap;
 use LaminasTest\Ldap as TestLdap;
+
+use function array_key_exists;
+use function array_merge;
+use function count;
+use function getenv;
 
 /**
  * @group      Laminas_Ldap
@@ -30,10 +37,19 @@ class UpdateTest extends TestLdap\AbstractOnlineTestCase
         parent::tearDown();
     }
 
-    protected function stripActiveDirectorySystemAttributes(&$entry)
+    protected function stripActiveDirectorySystemAttributes(array &$entry): void
     {
-        $adAttributes = ['distinguishedname', 'instancetype', 'name', 'objectcategory',
-                              'objectguid', 'usnchanged', 'usncreated', 'whenchanged', 'whencreated'];
+        $adAttributes = [
+            'distinguishedname',
+            'instancetype',
+            'name',
+            'objectcategory',
+            'objectguid',
+            'usnchanged',
+            'usncreated',
+            'whenchanged',
+            'whencreated',
+        ];
         foreach ($adAttributes as $attr) {
             if (array_key_exists($attr, $entry)) {
                 unset($entry[$attr]);

--- a/test/OfflineReconnectTest.php
+++ b/test/OfflineReconnectTest.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types=1);
 
 namespace LaminasTest\Ldap;
 
+use Laminas\Ldap\Ldap;
 use LaminasTest\Ldap\TestAsset\BuiltinFunctionMocks;
 use phpmock\Mock;
 
@@ -13,7 +15,7 @@ class OfflineReconnectTest extends OfflineTest
      * Not all tests need or are compatible with this, so it is called expliclty
      * by tests that do.
      */
-    protected function activateBindableOfflineMocks()
+    protected function activateBindableOfflineMocks(): void
     {
         BuiltinFunctionMocks::$ldap_connect_mock->enable();
         BuiltinFunctionMocks::$ldap_bind_mock->enable();
@@ -26,14 +28,14 @@ class OfflineReconnectTest extends OfflineTest
         Mock::disableAll();
     }
 
-    protected function reportErrorsAsConnectionFailure()
+    protected function reportErrorsAsConnectionFailure(): void
     {
         $ldap_errno = $this->getFunctionMock('Laminas\\Ldap', 'ldap_errno');
         $ldap_errno->expects($this->atLeastOnce())
             ->willReturn(-1);
     }
 
-    public function testAddingAttributesReconnect()
+    public function testAddingAttributesReconnect(): void
     {
         $this->activateBindableOfflineMocks();
         $this->reportErrorsAsConnectionFailure();
@@ -42,16 +44,16 @@ class OfflineReconnectTest extends OfflineTest
         $ldap_mod_add->expects($this->exactly(2))
             ->willReturnOnConsecutiveCalls(false, true);
 
-        $ldap = new \Laminas\Ldap\Ldap([
-            'host' => 'offline phony',
-            'reconnectAttempts' => 1
+        $ldap = new Ldap([
+            'host'              => 'offline phony',
+            'reconnectAttempts' => 1,
         ]);
         $ldap->bind();
         $ldap->addAttributes('foo', ['bar']);
         $this->assertEquals(1, $ldap->getReconnectsAttempted());
     }
 
-    public function testRemovingAttributesReconnect()
+    public function testRemovingAttributesReconnect(): void
     {
         $this->activateBindableOfflineMocks();
         $this->reportErrorsAsConnectionFailure();
@@ -60,9 +62,9 @@ class OfflineReconnectTest extends OfflineTest
         $ldap_mod_del->expects($this->exactly(2))
             ->willReturnOnConsecutiveCalls(false, true);
 
-        $ldap = new \Laminas\Ldap\Ldap([
-            'host' => 'offline phony',
-            'reconnectAttempts' => 1
+        $ldap = new Ldap([
+            'host'              => 'offline phony',
+            'reconnectAttempts' => 1,
         ]);
         $ldap->bind();
         $ldap->deleteAttributes('foo', ['bar']);

--- a/test/OfflineTest.php
+++ b/test/OfflineTest.php
@@ -1,12 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
 use Laminas\Config;
 use Laminas\Ldap;
+use Laminas\Ldap\Dn;
 use Laminas\Ldap\Exception\LdapException;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
+
+use function getenv;
 
 /**
  * @group      Laminas_Ldap
@@ -21,24 +26,19 @@ class OfflineTest extends TestCase
      *
      * @var Ldap\Ldap
      */
-    protected $ldap = null;
+    protected $ldap;
 
     /**
      * Setup operations run prior to each test method:
      *
      * * Creates an instance of Laminas\Ldap\Ldap
-     *
-     * @return void
      */
     protected function setUp(): void
     {
         $this->ldap = new Ldap\Ldap();
     }
 
-    /**
-     * @return void
-     */
-    public function testInvalidOptionResultsInException()
+    public function testInvalidOptionResultsInException(): void
     {
         $optionName = 'invalid';
         try {
@@ -49,7 +49,7 @@ class OfflineTest extends TestCase
         }
     }
 
-    public function testOptionsGetter()
+    public function testOptionsGetter(): void
     {
         $options = [
             'host'     => getenv('TESTS_LAMINAS_LDAP_HOST'),
@@ -59,68 +59,71 @@ class OfflineTest extends TestCase
         ];
         $ldap    = new Ldap\Ldap($options);
         $this->assertEquals([
-                                 'host'                   => getenv('TESTS_LAMINAS_LDAP_HOST'),
-                                 'port'                   => 0,
-                                 'useSsl'                 => false,
-                                 'username'               => getenv('TESTS_LAMINAS_LDAP_USERNAME'),
-                                 'password'               => getenv('TESTS_LAMINAS_LDAP_PASSWORD'),
-                                 'bindRequiresDn'         => false,
-                                 'baseDn'                 => getenv('TESTS_LAMINAS_LDAP_BASE_DN'),
-                                 'accountCanonicalForm'   => null,
-                                 'accountDomainName'      => null,
-                                 'accountDomainNameShort' => null,
-                                 'accountFilterFormat'    => null,
-                                 'allowEmptyPassword'     => false,
-                                 'useStartTls'            => false,
-                                 'optReferrals'           => false,
-                                 'tryUsernameSplit'       => true,
-                                 'reconnectAttempts'      => 0,
-                                 'networkTimeout'         => null,
-                                 'saslOpts'               => null,
-                            ], $ldap->getOptions());
+            'host'                   => getenv('TESTS_LAMINAS_LDAP_HOST'),
+            'port'                   => 0,
+            'useSsl'                 => false,
+            'username'               => getenv('TESTS_LAMINAS_LDAP_USERNAME'),
+            'password'               => getenv('TESTS_LAMINAS_LDAP_PASSWORD'),
+            'bindRequiresDn'         => false,
+            'baseDn'                 => getenv('TESTS_LAMINAS_LDAP_BASE_DN'),
+            'accountCanonicalForm'   => null,
+            'accountDomainName'      => null,
+            'accountDomainNameShort' => null,
+            'accountFilterFormat'    => null,
+            'allowEmptyPassword'     => false,
+            'useStartTls'            => false,
+            'optReferrals'           => false,
+            'tryUsernameSplit'       => true,
+            'reconnectAttempts'      => 0,
+            'networkTimeout'         => null,
+            'saslOpts'               => null,
+        ], $ldap->getOptions());
     }
 
-    public function testConfigObject()
+    public function testConfigObject(): void
     {
         $config = new Config\Config([
-                                         'host'     => getenv('TESTS_LAMINAS_LDAP_HOST'),
-                                         'username' => getenv('TESTS_LAMINAS_LDAP_USERNAME'),
-                                         'password' => getenv('TESTS_LAMINAS_LDAP_PASSWORD'),
-                                         'baseDn'   => getenv('TESTS_LAMINAS_LDAP_BASE_DN'),
-                                    ]);
+            'host'     => getenv('TESTS_LAMINAS_LDAP_HOST'),
+            'username' => getenv('TESTS_LAMINAS_LDAP_USERNAME'),
+            'password' => getenv('TESTS_LAMINAS_LDAP_PASSWORD'),
+            'baseDn'   => getenv('TESTS_LAMINAS_LDAP_BASE_DN'),
+        ]);
         $ldap   = new Ldap\Ldap($config);
         $this->assertEquals([
-                                 'host'                   => getenv('TESTS_LAMINAS_LDAP_HOST'),
-                                 'port'                   => 0,
-                                 'useSsl'                 => false,
-                                 'username'               => getenv('TESTS_LAMINAS_LDAP_USERNAME'),
-                                 'password'               => getenv('TESTS_LAMINAS_LDAP_PASSWORD'),
-                                 'bindRequiresDn'         => false,
-                                 'baseDn'                 => getenv('TESTS_LAMINAS_LDAP_BASE_DN'),
-                                 'accountCanonicalForm'   => null,
-                                 'accountDomainName'      => null,
-                                 'accountDomainNameShort' => null,
-                                 'accountFilterFormat'    => null,
-                                 'allowEmptyPassword'     => false,
-                                 'useStartTls'            => false,
-                                 'optReferrals'           => false,
-                                 'tryUsernameSplit'       => true,
-                                 'reconnectAttempts'      => 0,
-                                 'networkTimeout'         => null,
-                                 'saslOpts'               => null,
-                            ], $ldap->getOptions());
+            'host'                   => getenv('TESTS_LAMINAS_LDAP_HOST'),
+            'port'                   => 0,
+            'useSsl'                 => false,
+            'username'               => getenv('TESTS_LAMINAS_LDAP_USERNAME'),
+            'password'               => getenv('TESTS_LAMINAS_LDAP_PASSWORD'),
+            'bindRequiresDn'         => false,
+            'baseDn'                 => getenv('TESTS_LAMINAS_LDAP_BASE_DN'),
+            'accountCanonicalForm'   => null,
+            'accountDomainName'      => null,
+            'accountDomainNameShort' => null,
+            'accountFilterFormat'    => null,
+            'allowEmptyPassword'     => false,
+            'useStartTls'            => false,
+            'optReferrals'           => false,
+            'tryUsernameSplit'       => true,
+            'reconnectAttempts'      => 0,
+            'networkTimeout'         => null,
+            'saslOpts'               => null,
+        ], $ldap->getOptions());
     }
 
     /**
      * @dataProvider removingAttributesProvider
+     * @param string|Dn $dn
+     * @param array<string, mixed> $attributes
+     * @param array<string, mixed> $expectedAttributesToRemove
      */
     public function testRemovingAttributes(
         $dn,
-        $attributes,
-        $allowEmptyAttributes,
-        $expectedDn,
-        $expectedAttributesToRemove
-    ) {
+        array $attributes,
+        bool $allowEmptyAttributes,
+        string $expectedDn,
+        array $expectedAttributesToRemove
+    ): void {
         $ldap_mod_del = $this->getFunctionMock('Laminas\\Ldap', "ldap_mod_del");
         $ldap_mod_del->expects($this->once())
                      ->with(
@@ -134,37 +137,43 @@ class OfflineTest extends TestCase
         $this->assertSame($ldap, $ldap->deleteAttributes($dn, $attributes, $allowEmptyAttributes));
     }
 
-    public function removingAttributesProvider()
+    /**
+     * @return non-empty-array<
+     *     non-empty-string,
+     *     array{string|Dn, array<string, mixed>, bool, string, array<string, mixed>}
+     * >
+     */
+    public function removingAttributesProvider(): array
     {
         return [
             // Description => [dn, attributes, allow empty attributes, expected dn, expected attributes to remove]
-            'every attribute is used' => [
+            'every attribute is used'                          => [
                 'foo',
                 ['foo' => 'bar'],
                 false,
                 'foo',
-                ['foo' => 'bar']
+                ['foo' => 'bar'],
             ],
-            'Empty baz is removed' => [
+            'Empty baz is removed'                             => [
                 'foo',
                 ['foo' => 'bar', 'baz' => []],
                 false,
                 'foo',
-                ['foo' => 'bar']
+                ['foo' => 'bar'],
             ],
             'Empty baz is kept due to set $emptyAll-parameter' => [
                 'foo',
                 ['foo' => 'bar', 'baz' => []],
                 true,
                 'foo',
-                ['foo' => 'bar', 'baz' => []]
+                ['foo' => 'bar', 'baz' => []],
             ],
-            'DN is provided as DN-Object, not string' => [
-                \Laminas\Ldap\Dn::fromString('dc=foo'),
+            'DN is provided as DN-Object, not string'          => [
+                Dn::fromString('dc=foo'),
                 ['foo' => 'bar', 'baz' => []],
                 true,
                 'dc=foo',
-                ['foo' => 'bar', 'baz' => []]
+                ['foo' => 'bar', 'baz' => []],
             ],
         ];
     }
@@ -182,13 +191,16 @@ class OfflineTest extends TestCase
 
     /**
      * @dataProvider removingAttributesProvider
+     * @param string|Dn $dn
+     * @param array<string, mixed> $attributes
+     * @param array<string, mixed> $expectedAttributesToRemove
      */
     public function testAddingAttributes(
         $dn,
-        $attributes,
-        $allowEmptyAttributes,
-        $expectedDn,
-        $expectedAttributesToRemove
+        array $attributes,
+        bool $allowEmptyAttributes,
+        string $expectedDn,
+        array $expectedAttributesToRemove
     ) {
         $ldap_mod_add = $this->getFunctionMock('Laminas\\Ldap', "ldap_mod_add");
         $ldap_mod_add->expects($this->once())
@@ -216,13 +228,16 @@ class OfflineTest extends TestCase
 
     /**
      * @dataProvider removingAttributesProvider
+     * @param string|Dn $dn
+     * @param array<string, mixed> $attributes
+     * @param array<string, mixed> $expectedAttributesToRemove
      */
     public function testUpdatingAttributes(
         $dn,
-        $attributes,
-        $allowEmptyAttributes,
-        $expectedDn,
-        $expectedAttributesToRemove
+        array $attributes,
+        bool $allowEmptyAttributes,
+        string $expectedDn,
+        array $expectedAttributesToRemove
     ) {
         $ldap_mod_upd = $this->getFunctionMock('Laminas\\Ldap', "ldap_mod_replace");
         $ldap_mod_upd->expects($this->once())

--- a/test/SearchTest.php
+++ b/test/SearchTest.php
@@ -1,12 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
 use Laminas\Ldap;
 use Laminas\Ldap\Collection;
-use Laminas\Ldap\Exception;
+use Laminas\Ldap\Collection\DefaultIterator;
 use Laminas\Ldap\Exception\LdapException;
+use LaminasTest\Ldap\TestAsset\CollectionClassNotSubclassingLaminasLDAPCollection;
 use LaminasTest\Ldap\TestAsset\CustomNaming;
+
+use function getenv;
+use function strrev;
+use function strtoupper;
 
 /**
  * @group      Laminas_Ldap
@@ -44,7 +51,7 @@ class SearchTest extends AbstractOnlineTestCase
 
     public function testGetSingleIllegalEntryWithException()
     {
-        $dn    = $this->createDn('ou=Test99,');
+        $dn = $this->createDn('ou=Test99,');
         $this->expectException(LdapException::class);
         $entry = $this->getLDAP()->getEntry($dn, [], true);
     }
@@ -122,7 +129,7 @@ class SearchTest extends AbstractOnlineTestCase
 
     public function testIllegalSearch()
     {
-        $dn    = $this->createDn('ou=Node2,');
+        $dn = $this->createDn('ou=Node2,');
         $this->expectException(LdapException::class);
         $items = $this->getLDAP()->search('(objectClass=account)', $dn, Ldap\Ldap::SEARCH_SCOPE_SUB);
     }
@@ -281,7 +288,7 @@ class SearchTest extends AbstractOnlineTestCase
             getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'),
             Ldap\Ldap::SEARCH_SCOPE_SUB
         );
-        foreach ($items as $key => $item) {
+        foreach ($items as $key => $item) { // phpcs:ignore
             // do nothing - just iterate
         }
         $items->next();
@@ -317,7 +324,7 @@ class SearchTest extends AbstractOnlineTestCase
                 Ldap\Ldap::SEARCH_SCOPE_SUB,
                 [],
                 null,
-                'LaminasTest\Ldap\TestAsset\CollectionClassNotSubclassingLaminasLDAPCollection'
+                CollectionClassNotSubclassingLaminasLDAPCollection::class
             );
             $this->fail('Expected exception not thrown');
         } catch (LdapException $zle) {
@@ -337,10 +344,10 @@ class SearchTest extends AbstractOnlineTestCase
         $items = $this
             ->getLDAP()
             ->search([
-                          'filter' => '(objectClass=organizationalUnit)',
-                          'baseDn' => getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'),
-                          'scope'  => Ldap\Ldap::SEARCH_SCOPE_SUB
-                     ]);
+                'filter' => '(objectClass=organizationalUnit)',
+                'baseDn' => getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'),
+                'scope'  => Ldap\Ldap::SEARCH_SCOPE_SUB,
+            ]);
         $this->assertEquals(9, $items->count());
     }
 
@@ -352,10 +359,10 @@ class SearchTest extends AbstractOnlineTestCase
         $items = $this
             ->getLDAP()
             ->searchEntries([
-                                 'filter' => '(objectClass=organizationalUnit)',
-                                 'baseDn' => getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'),
-                                 'scope'  => Ldap\Ldap::SEARCH_SCOPE_SUB
-                            ]);
+                'filter' => '(objectClass=organizationalUnit)',
+                'baseDn' => getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'),
+                'scope'  => Ldap\Ldap::SEARCH_SCOPE_SUB,
+            ]);
         $this->assertCount(9, $items);
     }
 
@@ -387,12 +394,12 @@ class SearchTest extends AbstractOnlineTestCase
         $items   = $this
             ->getLDAP()
             ->searchEntries([
-                                 'filter'      => '(l=*)',
-                                 'baseDn'      => getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'),
-                                 'scope'       => Ldap\Ldap::SEARCH_SCOPE_SUB,
-                                 'sort'        => 'l',
-                                 'reverseSort' => true
-                            ]);
+                'filter'      => '(l=*)',
+                'baseDn'      => getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'),
+                'scope'       => Ldap\Ldap::SEARCH_SCOPE_SUB,
+                'sort'        => 'l',
+                'reverseSort' => true,
+            ]);
         foreach ($items as $key => $item) {
             $this->assertEquals($lSorted[$key], $item['l'][0]);
         }
@@ -465,7 +472,7 @@ class SearchTest extends AbstractOnlineTestCase
             getenv('TESTS_LAMINAS_LDAP_WRITEABLE_SUBTREE'),
             Ldap\Ldap::SEARCH_SCOPE_SUB
         );
-        $this->assertInstanceOf('\Laminas\Ldap\Collection\DefaultIterator', $items->getInnerIterator());
+        $this->assertInstanceOf(DefaultIterator::class, $items->getInnerIterator());
     }
 
     /**
@@ -627,7 +634,7 @@ class SearchTest extends AbstractOnlineTestCase
     }
 }
 
-function customNaming($attrib)
+function customNaming(string $attrib): string
 {
     return strtoupper(strrev($attrib));
 }

--- a/test/SortTest.php
+++ b/test/SortTest.php
@@ -1,8 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap;
 
 use Laminas\Ldap\Collection\DefaultIterator;
+use ReflectionObject;
+
+use function bin2hex;
+use function decbin;
+use function getenv;
+use function str_replace;
+use function strlen;
+use function strnatcasecmp;
 
 class SortTest extends AbstractOnlineTestCase
 {
@@ -30,12 +40,12 @@ class SortTest extends AbstractOnlineTestCase
             ['l']
         );
 
-        $iterator = new DefaultIterator($this->getLdap(), $search);
+        $iterator     = new DefaultIterator($this->getLdap(), $search);
         $sortFunction = function ($a, $b) {
             return 1;
         };
 
-        $reflectionObject = new \ReflectionObject($iterator);
+        $reflectionObject   = new ReflectionObject($iterator);
         $reflectionProperty = $reflectionObject->getProperty('sortFunction');
         $reflectionProperty->setAccessible(true);
         $this->assertEquals('strnatcasecmp', $reflectionProperty->getValue($iterator));
@@ -59,7 +69,7 @@ class SortTest extends AbstractOnlineTestCase
 
         $iterator = new DefaultIterator($this->getLdap(), $search);
 
-        $reflectionObject = new \ReflectionObject($iterator);
+        $reflectionObject   = new ReflectionObject($iterator);
         $reflectionProperty = $reflectionObject->getProperty('sortFunction');
         $reflectionProperty->setAccessible(true);
         $this->assertEquals('strnatcasecmp', $reflectionProperty->getValue($iterator));
@@ -89,8 +99,8 @@ class SortTest extends AbstractOnlineTestCase
             ['l']
         );
 
-        $iterator = new DefaultIterator($this->getLdap(), $search);
-        $sortFunction = function ($a, $b) use ($lSorted) {
+        $iterator     = new DefaultIterator($this->getLdap(), $search);
+        $sortFunction = function ($a, $b) {
             // Sort values by the number of "1" in their binary representation
             // and when that is equals by their position in the alphabet.
             $f = strlen(str_replace('0', '', decbin(bin2hex($a)))) -
@@ -104,7 +114,7 @@ class SortTest extends AbstractOnlineTestCase
         };
         $iterator->setSortFunction($sortFunction);
 
-        $reflectionObject = new \ReflectionObject($iterator);
+        $reflectionObject   = new ReflectionObject($iterator);
         $reflectionProperty = $reflectionObject->getProperty('sortFunction');
         $reflectionProperty->setAccessible(true);
         $this->assertEquals($sortFunction, $reflectionProperty->getValue($iterator));

--- a/test/TestAsset/BuiltinFunctionMocks.php
+++ b/test/TestAsset/BuiltinFunctionMocks.php
@@ -1,27 +1,37 @@
 <?php
+
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\TestAsset;
+
+use phpmock\Mock;
+
+use function fopen;
 
 class BuiltinFunctionMocks
 {
-    public static $ldap_connect_mock = null;
-    public static $ldap_bind_mock = null;
-    public static $ldap_set_option_mock = null;
+    /** @var Mock|null */
+    public static $ldap_connect_mock;
+    /** @var Mock|null */
+    public static $ldap_bind_mock;
+    /** @var Mock|null */
+    public static $ldap_set_option_mock;
 
     public static function createMocks()
     {
-        $ldap_connect_mock = new \phpmock\Mock(
+        $ldap_connect_mock = new Mock(
             'Laminas\\Ldap',
             'ldap_connect',
             function () {
-                static $a_resource = null;
-                if ($a_resource == null) {
-                    $a_resource = fopen(__FILE__, 'r');
+                static $resource = null;
+                if ($resource === null) {
+                    $resource = fopen(__FILE__, 'r');
                 }
-                return $a_resource;
+                return $resource;
             }
         );
 
-        $ldap_bind_mock = new \phpmock\Mock(
+        $ldap_bind_mock = new Mock(
             'Laminas\\Ldap',
             'ldap_bind',
             function () {
@@ -29,7 +39,7 @@ class BuiltinFunctionMocks
             }
         );
 
-        $ldap_set_option_mock = new \phpmock\Mock(
+        $ldap_set_option_mock = new Mock(
             'Laminas\\Ldap',
             'ldap_set_option',
             function () {
@@ -41,8 +51,8 @@ class BuiltinFunctionMocks
         $ldap_bind_mock->define();
         $ldap_set_option_mock->define();
 
-        static::$ldap_connect_mock = $ldap_connect_mock;
-        static::$ldap_bind_mock = $ldap_bind_mock;
+        static::$ldap_connect_mock    = $ldap_connect_mock;
+        static::$ldap_bind_mock       = $ldap_bind_mock;
         static::$ldap_set_option_mock = $ldap_set_option_mock;
     }
 }

--- a/test/TestAsset/CollectionClassNotSubclassingLaminasLDAPCollection.php
+++ b/test/TestAsset/CollectionClassNotSubclassingLaminasLDAPCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\TestAsset;
 
 class CollectionClassNotSubclassingLaminasLDAPCollection

--- a/test/TestAsset/CustomNaming.php
+++ b/test/TestAsset/CustomNaming.php
@@ -1,15 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Ldap\TestAsset;
+
+use function strrev;
+use function strtolower;
 
 class CustomNaming
 {
-    public static function name1($attrib)
+    public static function name1(string $attrib): string
     {
         return strtolower(strrev($attrib));
     }
 
-    public function name2($attrib)
+    public function name2(string $attrib): string
     {
         return strrev($attrib);
     }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+use LaminasTest\Ldap\TestAsset\BuiltinFunctionMocks;
+
 /*
  * Set error reporting to the level to which Laminas code must comply.
  */
@@ -40,4 +44,4 @@ putenv(sprintf("LDAPTLS_KEY=%s", getenv('TESTS_LAMINAS_LDAP_SASL_KEY')));
  * phpunit would find them and error while attempting to serialize global
  * variables.
  */
-\LaminasTest\Ldap\TestAsset\BuiltinFunctionMocks::createMocks();
+BuiltinFunctionMocks::createMocks();


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

Fixes #33