### PR TITLE
Add backslash to the ReturnTypeWillChange annotation to fix a new php 8.1 compatibility issue

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -99,7 +99,7 @@ class Collection implements Iterator, Countable
      *
      * @return int
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->iterator->count();
@@ -112,7 +112,7 @@ class Collection implements Iterator, Countable
      * @return array|null
      * @throws Exception\LdapException
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if ($this->count() < 1) {
@@ -167,7 +167,7 @@ class Collection implements Iterator, Countable
      *
      * @return int|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function key()
     {
         if ($this->count() > 0) {
@@ -185,7 +185,7 @@ class Collection implements Iterator, Countable
      *
      * @throws Exception\LdapException
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->iterator->next();
@@ -198,7 +198,7 @@ class Collection implements Iterator, Countable
      *
      * @throws Exception\LdapException
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->iterator->rewind();
@@ -212,7 +212,7 @@ class Collection implements Iterator, Countable
      *
      * @return bool
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         if (isset($this->cache[$this->current])) {

--- a/src/Collection/DefaultIterator.php
+++ b/src/Collection/DefaultIterator.php
@@ -223,7 +223,7 @@ class DefaultIterator implements Iterator, Countable
      *
      * @return int
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->itemCount;
@@ -236,7 +236,7 @@ class DefaultIterator implements Iterator, Countable
      * @return array|null
      * @throws LdapException
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if (! Handler::isResultEntryHandle($this->current)) {
@@ -297,7 +297,7 @@ class DefaultIterator implements Iterator, Countable
      * @throws LdapException
      * @return string|null
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function key()
     {
         if (! Handler::isResultEntryHandle($this->current)) {
@@ -326,7 +326,7 @@ class DefaultIterator implements Iterator, Countable
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->entries);
@@ -341,7 +341,7 @@ class DefaultIterator implements Iterator, Countable
      *
      * @return void
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->entries);
@@ -356,7 +356,7 @@ class DefaultIterator implements Iterator, Countable
      *
      * @return bool
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return Handler::isResultEntryHandle($this->current);

--- a/src/Dn.php
+++ b/src/Dn.php
@@ -397,7 +397,7 @@ class Dn implements ArrayAccess
      * @param  int $offset
      * @return bool
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $offset = (int) $offset;
@@ -414,7 +414,7 @@ class Dn implements ArrayAccess
      * @param  int $offset
      * @return array
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset, 1, null);
@@ -427,7 +427,7 @@ class Dn implements ArrayAccess
      * @param int   $offset
      * @param array $value
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->set($offset, $value);
@@ -439,7 +439,7 @@ class Dn implements ArrayAccess
      *
      * @param int $offset
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->remove($offset, 1);

--- a/src/Node.php
+++ b/src/Node.php
@@ -1006,7 +1006,7 @@ class Node extends Node\AbstractNode implements Iterator, RecursiveIterator
      * @return bool
      * @throws Exception\LdapException
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function hasChildren()
     {
         if (! is_array($this->children)) {
@@ -1026,7 +1026,7 @@ class Node extends Node\AbstractNode implements Iterator, RecursiveIterator
      * @return Node\ChildrenIterator
      * @throws Exception\LdapException
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function getChildren()
     {
         if (! is_array($this->children)) {
@@ -1065,7 +1065,7 @@ class Node extends Node\AbstractNode implements Iterator, RecursiveIterator
      *
      * @return array
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this;
@@ -1077,7 +1077,7 @@ class Node extends Node\AbstractNode implements Iterator, RecursiveIterator
      *
      * @return string
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->getRdnString();
@@ -1087,7 +1087,7 @@ class Node extends Node\AbstractNode implements Iterator, RecursiveIterator
      * Move forward to next attribute.
      * Implements Iterator
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->iteratorRewind = false;
@@ -1097,7 +1097,7 @@ class Node extends Node\AbstractNode implements Iterator, RecursiveIterator
      * Rewind the Iterator to the first attribute.
      * Implements Iterator
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->iteratorRewind = true;
@@ -1110,7 +1110,7 @@ class Node extends Node\AbstractNode implements Iterator, RecursiveIterator
      *
      * @return bool
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->iteratorRewind;

--- a/src/Node/AbstractNode.php
+++ b/src/Node/AbstractNode.php
@@ -419,7 +419,7 @@ abstract class AbstractNode implements ArrayAccess, Countable
      * @param  mixed  $value
      * @throws BadMethodCallException
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetSet($name, $value)
     {
         throw new Exception\BadMethodCallException();
@@ -435,7 +435,7 @@ abstract class AbstractNode implements ArrayAccess, Countable
      * @return mixed
      * @throws LdapException
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($name)
     {
         return $this->getAttribute($name, null);
@@ -452,7 +452,7 @@ abstract class AbstractNode implements ArrayAccess, Countable
      * @param  string $name
      * @throws BadMethodCallException
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetUnset($name)
     {
         throw new Exception\BadMethodCallException();
@@ -467,7 +467,7 @@ abstract class AbstractNode implements ArrayAccess, Countable
      * @param  string $name
      * @return bool
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetExists($name)
     {
         return $this->existsAttribute($name, false);
@@ -479,7 +479,7 @@ abstract class AbstractNode implements ArrayAccess, Countable
      *
      * @return int
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->currentData);


### PR DESCRIPTION
Hi,
I've got following kind of errors after updating from version 2.13.0 to 2.14.0 (now on branch 2.14.x):
```
[E_DEPRECATED] Return type of Laminas\Ldap\Collection\DefaultIterator::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice - ...\laminas\laminas-ldap\src\Collection\DefaultIterator.php:240
[E_ERROR] During inheritance of Iterator: Uncaught  - ...\laminas\laminas-ldap\src\Collection\DefaultIterator.php:35
```

Replacing `#[ReturnTypeWillChange]` with `#[\ReturnTypeWillChange]` solved the problem.
I don't know what changed since patch #23 where `#[ReturnTypeWillChange]` worked perfectly.
But it looks like PHP's error message has changed recently, so maybe `#[\ReturnTypeWillChange]` is now the correct and official syntax.

I'm using PHP 8.1.8 (cli) (built: Jul  5 2022 23:03:41) (NTS Visual C++ 2019 x86) on Windows 10.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no
