### PR TITLE
Make deprecations loud in test suite, to highlight problems from #36

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
          bootstrap="test/bootstrap.php"
          colors="true"
          defaultTestSuite="default"
+         convertDeprecationsToExceptions="true"
 >
   <coverage processUncoveredFiles="true">
     <include>
@@ -13,7 +14,7 @@
   <testsuites>
     <testsuite name="default">
       <directory>./test</directory>
-      <exclude>./test/ConnectTest.php</exclude>>
+      <exclude>./test/ConnectTest.php</exclude>
       <exclude>./test/OfflineReconnectTest.php</exclude>
       <exclude>./test/ReconnectTest.php</exclude>
     </testsuite>

--- a/src/Collection/DefaultIterator.php
+++ b/src/Collection/DefaultIterator.php
@@ -9,6 +9,7 @@ use Laminas\Ldap\ErrorHandler;
 use Laminas\Ldap\Exception;
 use Laminas\Ldap\Exception\LdapException;
 use Laminas\Ldap\Handler;
+use ReturnTypeWillChange;
 
 use function array_change_key_case;
 use function call_user_func;

--- a/src/Node.php
+++ b/src/Node.php
@@ -7,6 +7,7 @@ use Iterator;
 use Laminas\EventManager\EventManager;
 use Laminas\Ldap\Node\Collection;
 use RecursiveIterator;
+use ReturnTypeWillChange;
 
 use function array_key_exists;
 use function array_merge;

--- a/src/Node/AbstractNode.php
+++ b/src/Node/AbstractNode.php
@@ -9,6 +9,7 @@ use Laminas\Ldap\Dn;
 use Laminas\Ldap\Exception;
 use Laminas\Ldap\Exception\BadMethodCallException;
 use Laminas\Ldap\Exception\LdapException;
+use ReturnTypeWillChange;
 
 use function array_key_exists;
 use function array_merge;


### PR DESCRIPTION
`#[ReturnTypeWillChange]` attributes are required on PHP 8.1, where type signatures
will diverge with PHP 9.0, so we need these errors to become "loud" and visible.

This also fixes a minor `phpunit.xml.dist` syntax error (trailing `>`, probably C&P mistake)

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

Fixes #36
